### PR TITLE
Removing deprecated names

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The SoftwareContainer is composed of the following components:
 
 SoftwareContainer is maintained at https://github.com/Pelagicore/softwarecontainer
 
+Pelagicore maintainer:
+Tobias Olausson <tobias.olausson@pelagicore.com>
+
 # Building
 
 Building and installing is simple:

--- a/libsoftwarecontainer/include/libsoftwarecontainer.h
+++ b/libsoftwarecontainer/include/libsoftwarecontainer.h
@@ -41,8 +41,8 @@ class SoftwareContainerWorkspace :
 public:
     SoftwareContainerWorkspace(
             bool writeOften = false,
-            const std::string &containerRootFolder = PELAGICONTAIN_DEFAULT_WORKSPACE,
-            const std::string &configFilePath = PELAGICONTAIN_DEFAULT_CONFIG,
+            const std::string &containerRootFolder = SOFTWARECONTAINER_DEFAULT_WORKSPACE,
+            const std::string &configFilePath = SOFTWARECONTAINER_DEFAULT_CONFIG,
             unsigned int containerShutdownTimeout = 2)
         : m_writeOften(writeOften)
         , m_containerRoot(containerRootFolder)

--- a/libsoftwarecontainer/lxc-softwarecontainer.in
+++ b/libsoftwarecontainer/lxc-softwarecontainer.in
@@ -4,9 +4,6 @@
 # This LXC template is based on the busybox one shipped with LXC.
 # Original author: Daniel Lezcano <daniel.lezcano@free.fr>
 #
-# Pelagicore maintainer:
-# Tobias Olausson <tobias.olausson@pelagicore.com>
-#
 # LXC is free software, released under GNU LGPL 2.1
 #
 # Reader's guide: to get the full understanding of how the containers are

--- a/libsoftwarecontaineragent/src/CMakeLists.txt
+++ b/libsoftwarecontaineragent/src/CMakeLists.txt
@@ -27,7 +27,6 @@ add_library(softwarecontainer-agent-lib SHARED
 )
 
 TARGET_LINK_LIBRARIES( softwarecontainer-agent-lib
-    ${PELAGICORE_UTILS_LIBRARIES}
     ${DBUSCPP_LIBRARIES}
     ${DBUSCPPGLIB_LIBRARIES}
     ${GLIBMM_LIBRARIES}

--- a/softwarecontainer-config.h.in
+++ b/softwarecontainer-config.h.in
@@ -1,5 +1,5 @@
 #pragma once
 
-static constexpr const char* PELAGICONTAIN_DEFAULT_CONFIG = "@SYS_CONFIG_DIR@/softwarecontainer.conf";
+static constexpr const char* SOFTWARECONTAINER_DEFAULT_CONFIG = "@SYS_CONFIG_DIR@/softwarecontainer.conf";
 
-static constexpr const char* PELAGICONTAIN_DEFAULT_WORKSPACE = "/tmp/container/";
+static constexpr const char* SOFTWARECONTAINER_DEFAULT_WORKSPACE = "/tmp/container/";


### PR DESCRIPTION
Removing variables and text referring to pelagicontain
or Pelagicore, which should not.
