### PR TITLE
Don't add unit-test subdir when tests disabled

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -66,4 +66,6 @@ if (ENABLE_SYSTEMD)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/softwarecontainer-agent.service DESTINATION ${SYSTEMD_CONFIGURATION_FILES_DIR})
 endif()
 
-add_subdirectory(unit-test)
+if (ENABLE_TEST)
+   add_subdirectory(unit-test)
+endif()


### PR DESCRIPTION
In agent/CMakeLists.txt the unit-tests subdirectory was added even
if we disabled tests with -DENABLE_TESTS=off, this lead to a compile
error where it was looking for gmock/gmock.h which was never
installed and is not needed when compiling without tests.
