### PR TITLE
Added diagram support in user docs

### DIFF
--- a/doc/chapters/getting-started/index.rst
+++ b/doc/chapters/getting-started/index.rst
@@ -19,6 +19,27 @@ when integrating a launcher, that e.g. launches apps from a UI, when the laumche
 with root privileges. In that case the launcher can use the Agent D-Bus API without being root while
 the Agent has been started with root privileges.
 
+Below is an example of the major entities involved in a call to create a container:
+
+.. seqdiag::
+
+    seqdiag {
+        Launcher -> Agent [label = "CreateContainer (D-Bus call)", leftnote = "D-Bus side"]
+        Agent -> SoftwareContainerLib [label = "init()"];
+        SoftwareContainerLib -> ContainerAbstractInterface [label = "initialize()"]
+        SoftwareContainerLib <-- ContainerAbstractInterface [label = "ReturnCode"]
+        SoftwareContainerLib -> ContainerAbstractInterface [label = "create()"]
+        ContainerAbstractInterface -> liblxc [label = "lxc_container_new()", rightnote = "system side"]
+        ContainerAbstractInterface <-- liblxc
+        SoftwareContainerLib <-- ContainerAbstractInterface [label = "ReturnCode"]
+        SoftwareContainerLib -> ContainerAbstractInterface [label = "start()"]
+        ContainerAbstractInterface -> liblxc [label = "multiple calls"]
+        ContainerAbstractInterface <-- liblxc
+        SoftwareContainerLib <-- ContainerAbstractInterface
+        Agent <-- SoftwareContainerLib [label = "ReturnCode"]
+        Launcher <-- Agent [label = "ID"]
+    }
+
 
 Container config
 ================

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -34,7 +34,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
-    'sphinxcontrib.manpage'
+    'sphinxcontrib.manpage',
+    'sphinxcontrib.seqdiag'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -65,6 +66,11 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for seqdiag  -------------------------------------------------
+
+# This makes the text slightly easier to read but also more blurry...
+seqdiag_antialias = True
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
We use 'seqdiag' for diagram generation in the Sphinx docs.
Updated the cookbook revision and the Sphinx config and added
a diagram in the docs.
