### PR TITLE
Renamed SoftwareContainerLib and split Workspace

### DIFF
--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -34,7 +34,7 @@
 #include <ivi-profiling.h>
 
 #include "SoftwareContainerAgent_dbuscpp_adaptor.h"
-#include "libsoftwarecontainer.h"
+#include "softwarecontainer.h"
 #include "softwarecontainer-common.h"
 
 #include <jsonparser.h>
@@ -52,7 +52,7 @@ namespace softwarecontainer {
 class SoftwareContainerAgent : protected softwarecontainer::JSONParser
 {
     LOG_DECLARE_CLASS_CONTEXT("SCA", "SoftwareContainerAgent");
-    typedef std::unique_ptr<SoftwareContainerLib> SoftwareContainerLibPtr;
+    typedef std::unique_ptr<SoftwareContainer> SoftwareContainerPtr;
 
 public:
     SoftwareContainerAgent(Glib::RefPtr<Glib::MainContext> mainLoopContext
@@ -72,7 +72,7 @@ public:
     /**
      * Check whether the given containerID is valid and return a reference to the actual container
      */
-    bool checkContainer(ContainerID containerID, SoftwareContainerLib * &container);
+    bool checkContainer(ContainerID containerID, SoftwareContainer * &container);
 
     ReturnCode readConfigElement(const json_t *element);
 
@@ -108,12 +108,12 @@ public:
 
     void setGatewayConfigs(const uint32_t &containerID, const std::map<std::string, std::string> &configs);
 
-    std::shared_ptr<SoftwareContainerWorkspace> getSoftwareContainerWorkspace();
+    std::shared_ptr<Workspace> getWorkspace();
 
 private:
-    std::shared_ptr<SoftwareContainerWorkspace> m_softwarecontainerWorkspace;
-    std::vector<SoftwareContainerLibPtr> m_containers;
-    std::vector<SoftwareContainerLibPtr> m_preloadedContainers;
+    std::shared_ptr<Workspace> m_softwarecontainerWorkspace;
+    std::vector<SoftwareContainerPtr> m_containers;
+    std::vector<SoftwareContainerPtr> m_preloadedContainers;
     std::vector<CommandJob *> m_jobs;
     Glib::RefPtr<Glib::MainContext> m_mainLoopContext;
     size_t m_preloadCount;

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -34,7 +34,7 @@ public:
     int m_preloadCount = 1;
     bool m_shutdownContainers = true;
     int m_shutdownTimeout = 2;
-    std::shared_ptr<SoftwareContainerWorkspace> workspace;
+    std::shared_ptr<Workspace> workspace;
 
     void SetUp() override
     {
@@ -44,7 +44,7 @@ public:
                     , m_shutdownContainers
                     , m_shutdownTimeout);
 
-        workspace = sca->getSoftwareContainerWorkspace();
+        workspace = sca->getWorkspace();
     }
 
     void TearDown() override

--- a/libsoftwarecontainer/include/CMakeLists.txt
+++ b/libsoftwarecontainer/include/CMakeLists.txt
@@ -19,9 +19,10 @@
 
 
 set(HEADERS
-    libsoftwarecontainer.h
+    softwarecontainer.h
     container.h
     containerabstractinterface.h
+    workspace.h
     gateway.h
 )
 

--- a/libsoftwarecontainer/include/commandjob.h
+++ b/libsoftwarecontainer/include/commandjob.h
@@ -31,7 +31,7 @@ class CommandJob :
 public:
     static constexpr int UNASSIGNED_STREAM = -1;
 
-    CommandJob(SoftwareContainerLib &lib, const std::string &command);
+    CommandJob(SoftwareContainer &sc, const std::string &command);
     virtual ~CommandJob();
 
     ReturnCode setWorkingDirectory(const std::string &folder);

--- a/libsoftwarecontainer/include/functionjob.h
+++ b/libsoftwarecontainer/include/functionjob.h
@@ -30,7 +30,7 @@ class FunctionJob :
 public:
     static constexpr int UNASSIGNED_STREAM = -1;
 
-    FunctionJob(SoftwareContainerLib &lib, std::function<int()> command);
+    FunctionJob(SoftwareContainer &sc, std::function<int()> command);
     virtual ~FunctionJob();
 
     ReturnCode start();

--- a/libsoftwarecontainer/include/jobabstract.h
+++ b/libsoftwarecontainer/include/jobabstract.h
@@ -17,7 +17,7 @@
  * For further information see LICENSE
  */
 #pragma once
-#include "libsoftwarecontainer.h"
+#include "softwarecontainer.h"
 
 namespace softwarecontainer {
 /**
@@ -26,12 +26,12 @@ namespace softwarecontainer {
 class JobAbstract
 {
 protected:
-    LOG_SET_CLASS_CONTEXT(SoftwareContainerLib::getDefaultContext());
+    LOG_SET_CLASS_CONTEXT(SoftwareContainer::getDefaultContext());
 
 public:
     static constexpr int UNASSIGNED_STREAM = -1;
 
-    JobAbstract(SoftwareContainerLib &lib);
+    JobAbstract(SoftwareContainer &sc);
     virtual ~JobAbstract();
 
     void captureStdin();
@@ -57,7 +57,7 @@ public:
 
 protected:
     EnvironmentVariables m_env;
-    SoftwareContainerLib &m_lib;
+    SoftwareContainer &m_sc;
     pid_t m_pid = 0;
     int m_stdin[2] = {UNASSIGNED_STREAM, UNASSIGNED_STREAM};
     int m_stdout[2] = {UNASSIGNED_STREAM, UNASSIGNED_STREAM};

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -28,64 +28,20 @@
 #include <stdlib.h>
 
 #include <glibmm.h>
-
+#include "workspace.h"
 #include "gateway.h"
 
 namespace softwarecontainer {
 
-class SoftwareContainerWorkspace :
-    private FileToolkitWithUndo
-{
-    LOG_DECLARE_CLASS_CONTEXT("PCLW", "SoftwareContainer library workspace");
-
-public:
-    SoftwareContainerWorkspace(
-            bool enableWriteBuffer = false,
-            const std::string &containerRootFolder = SOFTWARECONTAINER_DEFAULT_WORKSPACE,
-            const std::string &configFilePath = SOFTWARECONTAINER_DEFAULT_CONFIG,
-            unsigned int containerShutdownTimeout = 2)
-        : m_enableWriteBuffer(enableWriteBuffer)
-        , m_containerRoot(containerRootFolder)
-        , m_containerConfig(configFilePath)
-        , m_containerShutdownTimeout(containerShutdownTimeout)
-    {
-        // Make sure path ends in '/' since it might not always be checked
-        if (m_containerRoot.back() != '/') {
-            m_containerRoot += "/";
-        }
-
-        if (isError(checkWorkspace())) {
-            log_error() << "Failed when checking workspace";
-            assert(false);
-        }
-    }
-
-    ~SoftwareContainerWorkspace()
-    {
-    }
-
-    /**
-     * @brief Check if the workspace is present and create it if needed
-     */
-    ReturnCode checkWorkspace();
-
-    bool m_enableWriteBuffer;
-    std::string m_containerRoot;
-    std::string m_containerConfig;
-    unsigned int m_containerShutdownTimeout;
-};
-
-std::shared_ptr<SoftwareContainerWorkspace> getDefaultWorkspace(bool enableWriteBuffer);
-
-class SoftwareContainerLib :
+class SoftwareContainer :
     private FileToolkitWithUndo
 {
 public:
     LOG_DECLARE_CLASS_CONTEXT("PCL", "SoftwareContainer library");
 
-    SoftwareContainerLib(std::shared_ptr<SoftwareContainerWorkspace> workspace = getDefaultWorkspace(false));
+    SoftwareContainer(std::shared_ptr<Workspace> workspace);
 
-    ~SoftwareContainerLib();
+    ~SoftwareContainer();
 
     /**
      * @brief Set the main loop
@@ -145,7 +101,7 @@ public:
 private:
     ReturnCode shutdownGateways();
 
-    std::shared_ptr<SoftwareContainerWorkspace> m_workspace;
+    std::shared_ptr<Workspace> m_workspace;
 
     std::string m_containerID;
     std::string m_containerName;

--- a/libsoftwarecontainer/include/workspace.h
+++ b/libsoftwarecontainer/include/workspace.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+
+#pragma once
+
+#include "filetoolkitwithundo.h"
+
+namespace softwarecontainer {
+
+/**
+ * @brief Holds information about the container workspace
+ */
+class Workspace :
+    private FileToolkitWithUndo
+{
+    LOG_DECLARE_CLASS_CONTEXT("PCLW", "SoftwareContainer library workspace");
+
+public:
+
+    /**
+     * @brief Creates a workspace.
+     *
+     * @param enableWriteBuffer Enable writebuffers on mountpoints
+     * @param containerRootDir The path at which the container resides in the host system
+     * @param containerConfigPath The path to the configuration lxc
+     * @param containerShutdownTimeout The timeout time for the softwarecontainer
+     */
+    Workspace(bool enableWriteBuffer = false,
+              const std::string &containerRootDir = SOFTWARECONTAINER_DEFAULT_WORKSPACE,
+              const std::string &containerConfigPath = SOFTWARECONTAINER_DEFAULT_CONFIG,
+              unsigned int containerShutdownTimeout = 2);
+
+    ~Workspace();
+
+    /**
+     * @brief Check if the workspace is present and create it if needed
+     */
+    ReturnCode checkWorkspace();
+
+    bool m_enableWriteBuffer;
+    std::string m_containerRootDir;
+    std::string m_containerConfigPath;
+    unsigned int m_containerShutdownTimeout;
+};
+
+}

--- a/libsoftwarecontainer/src/CMakeLists.txt
+++ b/libsoftwarecontainer/src/CMakeLists.txt
@@ -54,7 +54,8 @@ add_library(softwarecontainerlib SHARED
     gateway/gateway.cpp
     generators.cpp
     generators.h
-    libsoftwarecontainer.cpp
+    softwarecontainer.cpp
+    workspace.cpp
     jobs/jobabstract.cpp
     jobs/functionjob.cpp
     jobs/commandjob.cpp

--- a/libsoftwarecontainer/src/jobs/commandjob.cpp
+++ b/libsoftwarecontainer/src/jobs/commandjob.cpp
@@ -20,7 +20,7 @@
 #include "commandjob.h"
 
 CommandJob::CommandJob(
-    SoftwareContainerLib &lib, const std::string &command): JobAbstract(lib)
+    SoftwareContainer &sc, const std::string &command): JobAbstract(sc)
 {
     m_command = command;
 }
@@ -43,7 +43,7 @@ ReturnCode CommandJob::setUserID(uid_t userID)
 
 ReturnCode CommandJob::start()
 {
-    return m_lib.getContainer()->attach(m_command, &m_pid, m_env, m_userID,
+    return m_sc.getContainer()->attach(m_command, &m_pid, m_env, m_userID,
                 m_workingDirectory, m_stdin[0], m_stdout[1], m_stderr[1]);
 }
 

--- a/libsoftwarecontainer/src/jobs/functionjob.cpp
+++ b/libsoftwarecontainer/src/jobs/functionjob.cpp
@@ -20,7 +20,7 @@
 #include "functionjob.h"
 
 FunctionJob::FunctionJob(
-    SoftwareContainerLib &lib, std::function<int()> command): JobAbstract(lib)
+    SoftwareContainer &sc, std::function<int()> command): JobAbstract(sc)
 {
     m_command = command;
 }
@@ -31,7 +31,7 @@ FunctionJob::~FunctionJob()
 
 ReturnCode FunctionJob::start()
 {
-    return m_lib.getContainer()->executeInContainer(
+    return m_sc.getContainer()->executeInContainer(
         m_command, &m_pid, m_env, m_stdin[0], m_stdout[1], m_stderr[1]);
 }
 

--- a/libsoftwarecontainer/src/jobs/jobabstract.cpp
+++ b/libsoftwarecontainer/src/jobs/jobabstract.cpp
@@ -19,8 +19,8 @@
 
 #include "jobabstract.h"
 
-JobAbstract::JobAbstract(SoftwareContainerLib &lib) :
-    m_lib(lib)
+JobAbstract::JobAbstract(SoftwareContainer &sc) :
+    m_sc(sc)
 {
 }
 

--- a/libsoftwarecontainer/src/workspace.cpp
+++ b/libsoftwarecontainer/src/workspace.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include "workspace.h"
+
+Workspace::Workspace(bool enableWriteBuffer,
+            const std::string &containerRootDir,
+            const std::string &containerConfigPath,
+            unsigned int containerShutdownTimeout):
+         m_enableWriteBuffer(enableWriteBuffer),
+         m_containerRootDir(containerRootDir),
+         m_containerConfigPath(containerConfigPath),
+         m_containerShutdownTimeout(containerShutdownTimeout)
+{
+    // Make sure path ends in '/' since it might not always be checked
+    if (m_containerRootDir.back() != '/') {
+        m_containerRootDir += "/";
+    }
+
+    if (isError(checkWorkspace())) {
+        log_error() << "Failed when checking workspace";
+        assert(false);
+    }
+}
+
+Workspace::~Workspace()
+{
+}
+
+ReturnCode Workspace::checkWorkspace()
+{
+    if (!isDirectory(m_containerRootDir)) {
+        log_debug() << "Container root "
+                    << m_containerRootDir
+                    << " does not exist, trying to create";
+
+        if(isError(createDirectory(m_containerRootDir))) {
+            log_debug() << "Failed to create container root directory";
+            return ReturnCode::FAILURE;
+        }
+    }
+    
+#ifdef ENABLE_NETWORKGATEWAY
+    // TODO: Have a way to check for the bridge using C/C++ instead of a
+    // shell script. Libbridge and/or netfilter?
+    std::string cmdLine = INSTALL_PREFIX;
+    cmdLine += "/bin/setup_softwarecontainer.sh";
+    log_debug() << "Creating workspace : " << cmdLine;
+    int returnCode;
+    try {
+        Glib::spawn_sync("", Glib::shell_parse_argv(cmdLine),
+                         static_cast<Glib::SpawnFlags>(0),
+                         sigc::slot<void>(), nullptr,
+                         nullptr, &returnCode);
+
+    } catch (Glib::SpawnError e) {
+        log_error() << "Failed to spawn "
+                    << cmdLine << ": code "
+                    << e.code() << " msg: "
+                    << e.what();
+
+        return ReturnCode::FAILURE;
+    }
+
+    if (returnCode != 0) {
+        log_error() << "Return code of "
+                    << cmdLine << " is non-zero";
+        return ReturnCode::FAILURE;
+    }
+#endif
+
+    return ReturnCode::SUCCESS;
+}

--- a/libsoftwarecontainer/unit-test/cgroupsgateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/cgroupsgateway_unittest.cpp
@@ -32,7 +32,7 @@ public:
     void SetUp() override
     {
         gw = new CgroupsGateway();
-        SoftwareContainerLibTest::SetUp();
+        SoftwareContainerTest::SetUp();
     }
 };
 

--- a/libsoftwarecontainer/unit-test/dbusgateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/dbusgateway_unittest.cpp
@@ -47,7 +47,7 @@ public:
     void SetUp() override
     {
         gw = new MockDBusGateway(DBusGateway::SessionProxy, m_gatewayDir, m_containerName);
-        SoftwareContainerLibTest::SetUp();
+        SoftwareContainerTest::SetUp();
     }
 
     const std::string m_gatewayDir = "/tmp/dbusgateway-unit-test/";

--- a/libsoftwarecontainer/unit-test/devicenodegateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodegateway_unittest.cpp
@@ -31,7 +31,7 @@ public:
     void SetUp() override
     {
         gw = new DeviceNodeGateway();
-        SoftwareContainerLibTest::SetUp();
+        SoftwareContainerTest::SetUp();
     }
 
     const std::string NEW_DEVICE = "/dev/new_device";

--- a/libsoftwarecontainer/unit-test/envgateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/envgateway_unittest.cpp
@@ -30,7 +30,7 @@ public:
     void SetUp() override
     {
         gw = new EnvironmentGateway();
-        SoftwareContainerLibTest::SetUp();
+        SoftwareContainerTest::SetUp();
     }
 
     const std::string NAME  = "Environment_variable_test_name";

--- a/libsoftwarecontainer/unit-test/filegateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/filegateway_unittest.cpp
@@ -35,7 +35,7 @@ public:
     void SetUp() override
     {
         gw = new FileGateway();
-        SoftwareContainerLibTest::SetUp();
+        SoftwareContainerTest::SetUp();
 
         // Create file
         ASSERT_TRUE(writeToFile(FILE_PATH, FILE_CONTENT) == ReturnCode::SUCCESS);
@@ -43,7 +43,7 @@ public:
 
     void TearDown() override
     {
-        SoftwareContainerLibTest::TearDown();
+        SoftwareContainerTest::TearDown();
 
         // Remove file
         unlink(FILE_PATH.c_str());
@@ -102,7 +102,7 @@ TEST_F(FileGatewayTest, TestActivateCreateSymlink) {
 
 TEST_F(FileGatewayTest, TestActivateSetEnvWPrefixAndSuffix) {
     givenContainerIsSet(gw);
-    FunctionJob job = FunctionJob(*lib, [&] () {
+    FunctionJob job = FunctionJob(*sc, [&] () {
         const char* envC = getenv(ENV_VAR_NAME.c_str());
 
         if (envC == nullptr) {

--- a/libsoftwarecontainer/unit-test/networkgateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/networkgateway_unittest.cpp
@@ -40,7 +40,7 @@ protected:
     void SetUp() override
     {
         gw = new ::testing::NiceMock<MockNetworkGateway>();
-        SoftwareContainerLibTest::SetUp();
+        SoftwareContainerTest::SetUp();
     }
 
     const std::string VALID_FULL_CONFIG =

--- a/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
@@ -23,33 +23,33 @@
 
 void SoftwareContainerGatewayTest::givenContainerIsSet(Gateway *gw)
 {
-    lib->addGateway(gw);
+    sc->addGateway(gw);
 }
 
-void SoftwareContainerLibTest::run()
+void SoftwareContainerTest::run()
 {
     m_ml = Glib::MainLoop::create(m_context);
     m_ml->run();
 }
 
-void SoftwareContainerLibTest::exit()
+void SoftwareContainerTest::exit()
 {
     m_ml->quit();
 }
 
-void SoftwareContainerLibTest::SetUp()
+void SoftwareContainerTest::SetUp()
 {
     ::testing::Test::SetUp();
-    workspace = std::make_shared<SoftwareContainerWorkspace>(false);
-    lib = std::unique_ptr<SoftwareContainerLib>(new SoftwareContainerLib(workspace));
-    lib->setContainerIDPrefix("Test-");
-    lib->setMainLoopContext(m_context);
-    ASSERT_TRUE(isSuccess(lib->init()));
+    workspace = std::make_shared<Workspace>(false);
+    sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace));
+    sc->setContainerIDPrefix("Test-");
+    sc->setMainLoopContext(m_context);
+    ASSERT_TRUE(isSuccess(sc->init()));
 }
 
-void SoftwareContainerLibTest::TearDown()
+void SoftwareContainerTest::TearDown()
 {
     ::testing::Test::TearDown();
-    lib.reset();
+    sc.reset();
     workspace.reset();
 }

--- a/libsoftwarecontainer/unit-test/softwarecontainer_test.h
+++ b/libsoftwarecontainer/unit-test/softwarecontainer_test.h
@@ -30,13 +30,13 @@
 
 #include "gateway.h"
 #include "generators.h"
-#include "libsoftwarecontainer.h"
+#include "softwarecontainer.h"
 
-class SoftwareContainerLibTest : public ::testing::Test
+class SoftwareContainerTest : public ::testing::Test
 {
 public:
-    SoftwareContainerLibTest() { }
-    ~SoftwareContainerLibTest() { }
+    SoftwareContainerTest() { }
+    ~SoftwareContainerTest() { }
 
     void SetUp() override;
     void TearDown() override;
@@ -45,11 +45,11 @@ public:
 
     Glib::RefPtr<Glib::MainContext> m_context = Glib::MainContext::get_default();
     Glib::RefPtr<Glib::MainLoop> m_ml;
-    std::unique_ptr<SoftwareContainerLib> lib;
-    std::shared_ptr<SoftwareContainerWorkspace> workspace;
+    std::unique_ptr<SoftwareContainer> sc;
+    std::shared_ptr<Workspace> workspace;
 };
 
-class SoftwareContainerGatewayTest : public SoftwareContainerLibTest
+class SoftwareContainerGatewayTest : public SoftwareContainerTest
 {
 public:
     SoftwareContainerGatewayTest() { }


### PR DESCRIPTION
SoftwareContainerLib has been renamed to SoftwareContainer since the class itself is not a library and the naming is inconsistent.
The source files libsoftwarecontainer.cpp and .h are now called softwarecontainer.cpp and .h.

SoftwareContainerWorkspace has been renamed to Workspace and been split into a separate .h and .cpp file.
getDefaultWorkspace was not used by anything but one test in softwarecontainerlib_unittest.cpp and has been causing problems
and has therefore been removed.
