### PR TITLE
Pulse fix

### DIFF
--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -82,6 +82,12 @@ ReturnCode FileToolkitWithUndo::bindMount(const std::string &src, const std::str
     std::string fstype;
     const void *data = nullptr;
     int mountRes;
+
+    if (!existsInFileSystem(src)) {
+        log_error() << src << " does not exist on the host, can not bindMount";
+        return ReturnCode::FAILURE;
+    }
+
     log_debug() << "Bind-mounting " << src << " in " << dst << ", flags: " << flags;
 
     if(enableWriteBuffer) {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -34,7 +34,7 @@ echo "D-Bus per-session daemon address is: $DBUS_SESSION_BUS_ADDRESS"
 
 echo "### Launching pulseaudio ###"
 PULSE_SERVER=/tmp/pulse.sock
-pulseaudio --daemonize
+pulseaudio --daemonize --exit-idle-time=-1
 ppid=$!
 pactl load-module module-native-protocol-unix auth-anonymous=1 socket=$PULSE_SERVER
 export PULSE_SERVER=$PULSE_SERVER


### PR DESCRIPTION
## Fixed bug TestPulseaudioEnabled fail

The reason for the bug was that it took too long time before any stream were used
and as such pulseaudio exited due to being idle for too long. 
## Also

Checking that the source for bind mount exists on the host file system before attempting a bind mount
