### PR TITLE
Fixed timing issues in service tests

### DIFF
--- a/servicetest/run-tests.sh
+++ b/servicetest/run-tests.sh
@@ -24,5 +24,8 @@ for DIR in ${DIRECTORIES[@]}; do
         echo "Running service tests in $DIR"
         pushd $DIR > /dev/null
         py.test -v
+        # Sleep to allow some time for teardown in previous suite
+        # to have full effect before we run the next suite
+        sleep 1
         popd > /dev/null
 done


### PR DESCRIPTION
When running all suites, e.g. through the test
runner, the teardown in a suite seems to sometimes
take long enough time to create issues with the
setup in the following suite.
