### PR TITLE
Fix linking error

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(softwarecontainercommon SHARED
     recursivecopy.cpp
 )
 
+target_link_libraries(softwarecontainercommon
+   ${Jansson_LIBRARIES})
 
 install(FILES ${HEADERS} DESTINATION include/softwarecontainer)
 install(TARGETS softwarecontainercommon DESTINATION lib)


### PR DESCRIPTION
During linking following error occurs:

```
Linking CXX executable softwarecontainercommontest
../libsoftwarecontainercommon.so: undefined reference to `json_integer_value'
../libsoftwarecontainercommon.so: undefined reference to `json_string_value'
../libsoftwarecontainercommon.so: undefined reference to `json_object_get'
collect2: error: ld returned 1 exit status
```
