### PR TITLE
Changed user docs

### DIFF
--- a/doc/chapters/getting-started/index.rst
+++ b/doc/chapters/getting-started/index.rst
@@ -113,7 +113,7 @@ Start a container::
     /com/pelagicore/SoftwareContainerAgent \
     com.pelagicore.SoftwareContainerAgent.CreateContainer \
     string:"MyPrefix-" \
-    string:'[{"enableWriteBuffer": true}]'
+    string:'[{"enableWriteBuffer": false}]'
 
 The JSON string passed as argument to the ``config`` parameter is documented in the Container config section.
 


### PR DESCRIPTION
The Getting started example currently triggers a warning
that we are planning to fix. We might create unnecessary
confusion in the meantime so it's better to change the
example.
