### PR TITLE
common: Adds a memset to set stat struct to 0

### DIFF
--- a/common/softwarecontainer-common.cpp
+++ b/common/softwarecontainer-common.cpp
@@ -35,6 +35,8 @@ LOG_DECLARE_DEFAULT_CONTEXT(defaultLogContext, "MAIN", "Main context");
 struct stat getStat(const std::string &path)
 {
     struct stat st;
+    memset(&st, 0, sizeof(st));
+
     if (stat(path.c_str(), &st) == 0) {
         return st;
     }


### PR DESCRIPTION
Since the struct is allocated on the stack, all functions
and tests of functions that used the stat struct, would
sometimes fail because memory was randomly set.

Signed-off-by: Tobias Olausson tobias.olausson@pelagicore.com
