### PR TITLE
The container ID set by Agent is used for LXC ID

### DIFF
--- a/agent/softwarecontainer-agent.xml
+++ b/agent/softwarecontainer-agent.xml
@@ -6,7 +6,6 @@
         </method>
 
         <method name="CreateContainer">
-            <arg direction="in" type="s" name="prefix" />
             <arg direction="in" type="s" name="config" />
             <arg direction="out" type="u" name="containerID" />
         </method>

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -33,7 +33,6 @@ bool SoftwareContainerAgent::triggerPreload()
 {
     while (m_preloadedContainers.size() < m_preloadCount) {
         auto container = new SoftwareContainer(m_softwarecontainerWorkspace);
-        container->setContainerIDPrefix("Preload-");
 
         if (isError(container->preload())) {
             log_error() << "Preloading failed";
@@ -151,7 +150,7 @@ ContainerID SoftwareContainerAgent::createContainer(const std::string &prefix, c
 
     m_containers[availableID] = SoftwareContainerPtr(container);
     log_debug() << "Created container with ID :" << availableID;
-    container->setContainerIDPrefix(prefix);
+    container->setContainerID(prefix + std::to_string(availableID));
     container->setMainLoopContext(m_mainLoopContext);
     container->init();
 

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -133,7 +133,7 @@ ContainerID SoftwareContainerAgent::findSuitableId()
     return availableID;
 }
 
-SoftwareContainer* SoftwareContainerAgent::makeSoftwareContainer(const ContainerID &containerID)
+SoftwareContainer *SoftwareContainerAgent::makeSoftwareContainer(const ContainerID &containerID)
 {
     log_debug() << "Created container with ID :" << containerID;
     auto container = new SoftwareContainer(m_softwarecontainerWorkspace, "SC-" + std::to_string(containerID));

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -40,7 +40,7 @@ bool SoftwareContainerAgent::triggerPreload()
             return false;
         }
         auto pair = std::pair<ContainerID, SoftwareContainerPtr>(availableID, SoftwareContainerPtr(container));
-        m_preloadedContainers.push_back(std::move(pair));
+        m_preloadedContainers.push(std::move(pair));
     }
 
     return true;
@@ -150,8 +150,8 @@ ContainerID SoftwareContainerAgent::createContainer(const std::string &config)
     SoftwareContainer *container;
     ContainerID availableID;
     if (!m_preloadedContainers.empty()) {
-        auto pair = std::move(m_preloadedContainers.back());
-        m_preloadedContainers.pop_back();
+        auto pair = std::move(m_preloadedContainers.front());
+        m_preloadedContainers.pop();
 
         availableID = pair.first;
         container   = pair.second.release();

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -114,13 +114,12 @@ public:
     /**
      * @brief Create a new container
      *
-     * @param prefix a string to prefix the container name with
      * @param config container-wide configuration string
      *
      * @return ContainerID for the newly created container
      *
      */
-    ContainerID createContainer(const std::string &prefix, const std::string &config);
+    ContainerID createContainer(const std::string &config);
 
 
     /**
@@ -213,6 +212,9 @@ public:
     std::shared_ptr<Workspace> getWorkspace();
 
 private:
+    // Helper for creating software container instances
+    SoftwareContainer* makeSoftwareContainer(const ContainerID &containerID);
+
     // Pre-loads container until the we have as many as configured
     bool triggerPreload();
     // Find a job given a pid

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -226,7 +226,7 @@ private:
     // List of containers in use
     std::map<ContainerID, SoftwareContainerPtr> m_containers;
     // List of pre-loaded containers
-    std::vector<SoftwareContainerPtr> m_preloadedContainers;
+    std::vector<std::pair<ContainerID, SoftwareContainerPtr>> m_preloadedContainers;
     // List of running jobs
     std::vector<CommandJob *> m_jobs;
 

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -47,7 +47,7 @@
 
 #include <jsonparser.h>
 #include "commandjob.h"
-
+#include <queue>
 
 
 /**
@@ -225,10 +225,14 @@ private:
     ContainerID findSuitableId();
 
     std::shared_ptr<Workspace> m_softwarecontainerWorkspace;
+
     // List of containers in use
     std::map<ContainerID, SoftwareContainerPtr> m_containers;
-    // List of pre-loaded containers
-    std::vector<std::pair<ContainerID, SoftwareContainerPtr>> m_preloadedContainers;
+
+    // Queue of pre-loaded containers
+    // Push and pop are the only operations that is applied to this collection
+    // That is why it is a std::queue and not a std::map
+    std::queue<std::pair<ContainerID, SoftwareContainerPtr>> m_preloadedContainers;
     // List of running jobs
     std::vector<CommandJob *> m_jobs;
 

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -213,7 +213,7 @@ public:
 
 private:
     // Helper for creating software container instances
-    SoftwareContainer* makeSoftwareContainer(const ContainerID &containerID);
+    SoftwareContainer *makeSoftwareContainer(const ContainerID &containerID);
 
     // Pre-loads container until the we have as many as configured
     bool triggerPreload();

--- a/agent/src/softwarecontaineragentadaptor.cpp
+++ b/agent/src/softwarecontaineragentadaptor.cpp
@@ -43,9 +43,9 @@ bool softwarecontainer::SoftwareContainerAgentAdaptor::SetCapabilities(const uin
     return m_agent.setCapabilities(containerID, capabilities);
 }
 
-uint32_t softwarecontainer::SoftwareContainerAgentAdaptor::CreateContainer(const std::string &name, const std::string &config)
+uint32_t softwarecontainer::SoftwareContainerAgentAdaptor::CreateContainer(const std::string &config)
 {
-    return m_agent.createContainer(name, config);
+    return m_agent.createContainer(config);
 }
 
 void softwarecontainer::SoftwareContainerAgentAdaptor::SetContainerName(const uint32_t &containerID, const std::string &name)

--- a/agent/src/softwarecontaineragentadaptor.h
+++ b/agent/src/softwarecontaineragentadaptor.h
@@ -32,7 +32,7 @@ public:
 
     bool SetCapabilities(const uint32_t &containerID, const std::vector<std::string> &capabilities) override;
 
-    uint32_t CreateContainer(const std::string &name, const std::string &config) override;
+    uint32_t CreateContainer(const std::string &config) override;
 
     void SetContainerName(const uint32_t &containerID, const std::string &name) override;
 

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -60,14 +60,14 @@ public:
 
 TEST_F(SoftwareContainerAgentTest, CreatAndCheckContainer) {
     SoftwareContainer *container;
-    ContainerID id = sca->createContainer("iejr-", "");
+    ContainerID id = sca->createContainer("");
     bool retval = sca->checkContainer(id, container);
     ASSERT_TRUE(retval == true);
 }
 
 TEST_F(SoftwareContainerAgentTest, DeleteContainer) {
     SoftwareContainer *container;
-    ContainerID id = sca->createContainer("iejr-", "");
+    ContainerID id = sca->createContainer("");
     sca->deleteContainer(id);
     bool retval = sca->checkContainer(id, container);
     ASSERT_TRUE(retval == false);
@@ -77,7 +77,7 @@ TEST_F(SoftwareContainerAgentTest, DeleteContainer) {
  *TBD: This test needs to be fixed, somethings going on in it.
 TEST_F(SoftwareContainerAgentTest, CreateContainerWithConf) {
     log_error() << "gobbles1";
-    ContainerID id = sca->createContainer("iejr-", "[{\"enableWriteBuffer\": true}]");
+    ContainerID id = sca->createContainer("[{\"enableWriteBuffer\": true}]");
     // This is actually only true if no other containers have been created
     // before this one. Might need to be fixed somehow.
     log_error() << "gobbles2";

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -38,13 +38,18 @@ public:
 
     void SetUp() override
     {
-        sca = new SoftwareContainerAgent(
-            m_context
-            , m_preloadCount
-            , m_shutdownContainers
-            , m_shutdownTimeout);
+        try {
+            sca = new SoftwareContainerAgent(
+                m_context
+                , m_preloadCount
+                , m_shutdownContainers
+                , m_shutdownTimeout);
 
-        workspace = sca->getWorkspace();
+            workspace = sca->getWorkspace();
+        } catch(ReturnCode failure) {
+            log_error() << "Exception in software agent constructor";
+            ASSERT_TRUE(false);
+        }
     }
 
     void TearDown() override

--- a/doc/chapters/api/index.rst
+++ b/doc/chapters/api/index.rst
@@ -36,7 +36,6 @@ CreateContainer
 Creates a new container and returns created container id.
 
 :Parameters:
-        :prefix: ``string`` prefix for name of back-end container.
         :config: ``string`` config file in json format.
         
                 Example config JSON::

--- a/doc/chapters/developers/index.rst
+++ b/doc/chapters/developers/index.rst
@@ -37,7 +37,7 @@ subsequently uses:
     Agent -> SoftwareContainer [label = "new()"]
     Agent <-- SoftwareContainer
 
-    Agent -> SoftwareContainer [label = "setContainerIDPrefix()"]
+    Agent -> SoftwareContainer [label = "setContainerID()"]
     Agent <-- SoftwareContainer
 
     Agent -> SoftwareContainer [label = "setMainLoopContext()"]

--- a/doc/chapters/filesystem/index.rst
+++ b/doc/chapters/filesystem/index.rst
@@ -84,7 +84,7 @@ protection for the filesystem by only allowing a final write of the changes in
 the upper layer when the container is shutting down.
 
 To enable the write buffer, set the ``enableWriteBuffer`` option in the
-``com.pelagicore.SoftwareContainerAgent.CreateContainer(prefix, config)`` call.
+``com.pelagicore.SoftwareContainerAgent.CreateContainer(config)`` call.
 This is done using the config parameter in specific, for example, this JSON
 config::
 

--- a/doc/chapters/getting-started/index.rst
+++ b/doc/chapters/getting-started/index.rst
@@ -112,7 +112,6 @@ Start a container::
     --dest=com.pelagicore.SoftwareContainerAgent \
     /com/pelagicore/SoftwareContainerAgent \
     com.pelagicore.SoftwareContainerAgent.CreateContainer \
-    string:"MyPrefix-" \
     string:'[{"enableWriteBuffer": false}]'
 
 The JSON string passed as argument to the ``config`` parameter is documented in the Container config section.
@@ -140,7 +139,7 @@ Parameters:
 The method assumes the path ``pathInHost`` exists, so choose another path if it is more convenient.
 The result of the method is that the content of '/home/vagrant/container-test' will be
 visible in the path ``/gateways/app`` inside the container. The actual location on the host can be found in
-``/tmp/container/MyPrefix-<generated-name>/gateways/`` where the created ``app`` directory will be.
+``/tmp/container/SC-<container ID>/gateways/`` where the created ``app`` directory will be.
 
 
 Launch something in the container::

--- a/examples/simple/launch.sh
+++ b/examples/simple/launch.sh
@@ -71,7 +71,7 @@ $PCCMD org.freedesktop.DBus.Introspectable.Introspect
 $PCCMD com.pelagicore.SoftwareContainerAgent.Ping
 
 # Create a new container
-$PCCMD com.pelagicore.SoftwareContainerAgent.CreateContainer string:prefix string:'[{"writeOften": "0"}]'
+$PCCMD com.pelagicore.SoftwareContainerAgent.CreateContainer string:'[{"writeOften": "0"}]'
 
 # Expose a directory to the container
 $PCCMD com.pelagicore.SoftwareContainerAgent.BindMountFolderInContainer uint32:0 string:${SCRIPTPATH} string:app boolean:true

--- a/libsoftwarecontainer/include/container.h
+++ b/libsoftwarecontainer/include/container.h
@@ -75,8 +75,7 @@ public:
      * @param shutdownTimeout Timeout for shutdown of container.
      */
     Container(
-            const std::string &id
-            , const std::string &name
+            const std::string id
             , const std::string &configFile
             , const std::string &containerRoot
             , bool enableWriteBuffer = false
@@ -177,14 +176,9 @@ private:
     /**
      * @brief The unique name of the LXC container
      */
-    const std::string &m_id;
+    const std::string m_id;
 
     std::string m_rootFSPath;
-
-    /**
-     * @brief The name assigned to the container
-     */
-    const std::string &m_name;
 
     /**
      * @brief Pointer to the LXC container

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -40,7 +40,7 @@ class SoftwareContainer :
 public:
     LOG_DECLARE_CLASS_CONTEXT("PCL", "SoftwareContainer library");
 
-    SoftwareContainer(std::shared_ptr<Workspace> workspace);
+    SoftwareContainer(std::shared_ptr<Workspace> workspace, const std::string &id);
 
     ~SoftwareContainer();
 
@@ -67,14 +67,9 @@ public:
     ReturnCode init();
 
     std::shared_ptr<ContainerAbstractInterface> getContainer();
-    const std::string &getContainerID();
     std::string getContainerDir();
     std::string getGatewayDir();
 
-    /**
-     * @brief Sets what ID will be used for the LXC container when creating it.
-     */
-    void setContainerID(const std::string &newID);
     void setContainerName(const std::string &name);
 
     ObservableProperty<ContainerState> &getContainerState();
@@ -103,7 +98,6 @@ private:
 
     std::shared_ptr<Workspace> m_workspace;
 
-    std::string m_containerID;
     std::string m_containerName;
     ObservableWritableProperty<ContainerState> m_containerState;
 

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -71,10 +71,11 @@ public:
     std::string getContainerDir();
     std::string getGatewayDir();
 
-    void setContainerIDPrefix(const std::string &prefix);
+    /**
+     * @brief Sets what ID will be used for the LXC container when creating it.
+     */
+    void setContainerID(const std::string &newID);
     void setContainerName(const std::string &name);
-
-    void validateContainerID();
 
     ObservableProperty<ContainerState> &getContainerState();
 

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -57,15 +57,15 @@ void Container::init_lxc()
     }
 }
 
-Container::Container(const std::string &id, const std::string &name, const std::string &configFile,
+Container::Container(const std::string id, const std::string &configFile,
         const std::string &containerRoot, bool enableWriteBuffer, int shutdownTimeout) :
     m_configFile(configFile),
     m_id(id),
-    m_name(name),
     m_containerRoot(containerRoot),
     m_enableWriteBuffer(enableWriteBuffer),
     m_shutdownTimeout(shutdownTimeout)
 {
+    log_debug() << "Container constructed with " + id;
     init_lxc();
 }
 
@@ -113,7 +113,6 @@ std::string Container::toString()
     ss << "LXC " << id() << " ";
     if (m_container != nullptr) {
         ss << "id: " << id()
-           << " name : " << m_name
            << " / state:" << m_container->state(m_container)
            << " / initPID:" << m_container->init_pid(m_container)
            << " / LastError: " << m_container->error_string

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -65,8 +65,8 @@ Container::Container(const std::string id, const std::string &configFile,
     m_enableWriteBuffer(enableWriteBuffer),
     m_shutdownTimeout(shutdownTimeout)
 {
-    log_debug() << "Container constructed with " + id;
     init_lxc();
+    log_debug() << "Container constructed with " << id;
 }
 
 Container::~Container()

--- a/libsoftwarecontainer/src/gateway/networkgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/networkgateway.cpp
@@ -251,7 +251,7 @@ bool NetworkGateway::generateIP()
     log_debug() << "Generating ip-address";
     const char *ipAddrNet = m_gateway.substr(0, m_gateway.size() - 1).c_str();
 
-    m_ip = m_generator.gen_ip_addr(ipAddrNet);
+    m_ip = m_generator.genIPAddr(ipAddrNet);
     log_debug() << "IP set to " << m_ip;
 
     return true;

--- a/libsoftwarecontainer/src/generators.cpp
+++ b/libsoftwarecontainer/src/generators.cpp
@@ -27,20 +27,19 @@
 /*
  * Increase the counter and return an IP number based on that.
  */
-std::string Generator::gen_ip_addr(const char *ip_addr_net)
+std::string Generator::genIPAddr(const char *ipAddrNet)
 {
-
     counter++;
     if (counter < 2 || counter > 254) {
         counter = 2;
     }
 
     char ip[20];
-    snprintf(ip, sizeof(ip), "%s%d", ip_addr_net, counter);
+    snprintf(ip, sizeof(ip), "%s%d", ipAddrNet, counter);
     return std::string(ip);
 }
 
-std::string Generator::gen_ct_name()
+std::string Generator::genName()
 {
     static const char alphanum[] = "abcdefghijklmnopqrstuvwxyz";
     struct timeval time;

--- a/libsoftwarecontainer/src/generators.h
+++ b/libsoftwarecontainer/src/generators.h
@@ -48,7 +48,7 @@ public:
      * @param ip_addr_net A 24 bit network portion of an IP address
      * @return A string representing an IP address
      */
-    std::string gen_ip_addr(const char *ip_addr_net);
+    std::string genIPAddr(const char *ipAddrNet);
 
     /**
      * @brief Generate a container name
@@ -58,7 +58,7 @@ public:
      * @return name upon success
      * @return NULL upon failure
      */
-    static std::string gen_ct_name();
+    static std::string genName();
 
 private:
     int counter = 0;

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -55,7 +55,6 @@ SoftwareContainer::SoftwareContainer(std::shared_ptr<Workspace> workspace, const
                               m_workspace->m_enableWriteBuffer,
                               m_workspace->m_containerShutdownTimeout))
 {
-    log_debug() << "Software container called with " + containerID;
     m_containerState = ContainerState::CREATED;
 }
 

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -68,11 +68,9 @@ void SoftwareContainer::setMainLoopContext(Glib::RefPtr<Glib::MainContext> mainL
     m_mainLoopContext = mainLoopContext;
 }
 
-
-void SoftwareContainer::setContainerIDPrefix(const std::string &name)
+void SoftwareContainer::setContainerID(const std::string &newID)
 {
-    m_containerID = name + Generator::gen_ct_name();
-    log_debug() << "Assigned container ID " << m_containerID;
+    m_containerID = newID;
 }
 
 void SoftwareContainer::setContainerName(const std::string &name)
@@ -81,16 +79,13 @@ void SoftwareContainer::setContainerName(const std::string &name)
     log_debug() << m_container->toString();
 }
 
-void SoftwareContainer::validateContainerID()
-{
-    if (m_containerID.size() == 0) {
-        setContainerIDPrefix("PLC-");
-    }
-}
-
-
 ReturnCode SoftwareContainer::preload()
 {
+    if (m_containerID.empty()) {
+        const std::string newID = "SC-PRELOADED-" + Generator::gen_ct_name();
+        setContainerID(newID);
+    }
+
     log_debug() << "Initializing container";
     if (isError(m_container->initialize())) {
         log_error() << "Could not setup container for preloading";
@@ -116,7 +111,10 @@ ReturnCode SoftwareContainer::preload()
 
 ReturnCode SoftwareContainer::init()
 {
-    validateContainerID();
+    if (m_containerID.empty()) {
+        const std::string newID = "SC-" + Generator::gen_ct_name();
+        setContainerID(newID);
+    }
 
     if (m_mainLoopContext->gobj() == nullptr) {
         log_error() << "Main loop context must be set first !";

--- a/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
@@ -42,7 +42,7 @@ void SoftwareContainerTest::SetUp()
     ::testing::Test::SetUp();
     workspace = std::make_shared<Workspace>(false);
 
-    const std::string id = "SC-TEST-" + Generator::gen_ct_name();
+    const std::string id = "SC-TEST-" + Generator::genName();
     sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace, id));
     sc->setMainLoopContext(m_context);
     ASSERT_TRUE(isSuccess(sc->init()));

--- a/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
@@ -42,7 +42,6 @@ void SoftwareContainerTest::SetUp()
     ::testing::Test::SetUp();
     workspace = std::make_shared<Workspace>(false);
     sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace));
-    sc->setContainerIDPrefix("Test-");
     sc->setMainLoopContext(m_context);
     ASSERT_TRUE(isSuccess(sc->init()));
 }

--- a/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainer_test.cpp
@@ -41,7 +41,9 @@ void SoftwareContainerTest::SetUp()
 {
     ::testing::Test::SetUp();
     workspace = std::make_shared<Workspace>(false);
-    sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace));
+
+    const std::string id = "SC-TEST-" + Generator::gen_ct_name();
+    sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace, id));
     sc->setMainLoopContext(m_context);
     ASSERT_TRUE(isSuccess(sc->init()));
 }

--- a/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
@@ -575,7 +575,7 @@ TEST(SoftwareContainer, MultithreadTest) {
     static const int TIMEOUT = 20;
 
     std::shared_ptr<Workspace> workspacePtr(new Workspace());
-    SoftwareContainer lib(workspacePtr);
+    SoftwareContainer lib(workspacePtr, "SC-TEST-MultithreadTest");
     lib.setMainLoopContext(Glib::MainContext::get_default());
 
     bool finished = false;

--- a/libsoftwarecontaineragent/include/libsoftwarecontaineragent.h
+++ b/libsoftwarecontaineragent/include/libsoftwarecontaineragent.h
@@ -62,7 +62,7 @@ public:
 
     ReturnCode writeToStdIn(pid_t pid, const void *data, size_t length);
 
-    ReturnCode createContainer(const std::string &idPrefix, ContainerID &containerID, const std::string &config);
+    ReturnCode createContainer(ContainerID &containerID, const std::string &config);
 
     ReturnCode setContainerName(ContainerID containerID, const std::string &name);
 
@@ -109,7 +109,7 @@ public:
             config = "{enableWriteBuffer: \"1\"}";
         else
             config = "{enableWriteBuffer: \"0\"}";
-        auto ret = m_agent.createContainer(m_name, m_containerID, config);
+        auto ret = m_agent.createContainer(m_containerID, config);
         if (ret == ReturnCode::SUCCESS) {
             m_containerState = ContainerState::PRELOADED;
         }

--- a/libsoftwarecontaineragent/src/libsoftwarecontaineragent.cpp
+++ b/libsoftwarecontaineragent/src/libsoftwarecontaineragent.cpp
@@ -137,9 +137,9 @@ void Agent::setGatewayConfigs(ContainerID containerID, const GatewayConfiguratio
     getProxy().SetGatewayConfigs(containerID, config);
 }
 
-ReturnCode Agent::createContainer(const std::string &idPrefix, ContainerID &containerID, const std::string &config)
+ReturnCode Agent::createContainer(ContainerID &containerID, const std::string &config)
 {
-    containerID = getProxy().CreateContainer(idPrefix, config);
+    containerID = getProxy().CreateContainer(config);
     return bool2ReturnCode(containerID != INVALID_CONTAINER_ID);
 }
 

--- a/servicetest/capabilities/test_caps.py
+++ b/servicetest/capabilities/test_caps.py
@@ -35,7 +35,6 @@ def logfile_path():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.PREFIX: "caps-test-",
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
     Container.HOST_PATH: CURRENT_DIR

--- a/servicetest/dbus/test_dbus.py
+++ b/servicetest/dbus/test_dbus.py
@@ -43,7 +43,6 @@ HOST_PATH = os.path.dirname(os.path.abspath(__file__))
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.PREFIX: "dbus-test-",
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
     Container.HOST_PATH: HOST_PATH

--- a/servicetest/filesystem/test_filesystem.py
+++ b/servicetest/filesystem/test_filesystem.py
@@ -35,7 +35,6 @@ def logfile_path():
     return CURRENT_DIR + "/test.log"
 
 DATA = {
-    Container.PREFIX: "dbus-test-",
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
     Container.HOST_PATH: CURRENT_DIR

--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -47,7 +47,6 @@ class Container():
 
     # Static class members used by tests for container "data" dict keys. See the documentation
     # for the start() method for details.
-    PREFIX = "prefix"
     CONFIG = "config"
     BIND_MOUNT_DIR = "bind-mount-dir"
     HOST_PATH = "host-path"
@@ -108,7 +107,6 @@ class Container():
 
             The user should pass a dict like e.g.:
             {
-                Container.PREFIX: "dbus-test-",
                 Container.CONFIG: "{enableWriteBuffer: false}",
                 Container.HOST_PATH: my_path_string_variable,
                 Container.BIND_MOUNT_DIR: "app"
@@ -116,13 +114,11 @@ class Container():
 
             The values in the dict are passed as arguments to the D-Bus methods on SoftwareContainerAgent.
             The dict is mapped like so:
-            Container.PREFIX - first argument to SoftwareContainerAgent::CreateContainer
-            Container.CONFIG - second argument to SoftwareContainerAgent::CreateContainer
+            Container.CONFIG - argument to SoftwareContainerAgent::CreateContainer
             Container.HOST_PATH - second argument to SoftwareContainerAgent::BindMountFolderInContainer
             Container.BIND_MOUNT_DIR - third argument to SoftwareContainerAgent::BindMountFolderInContainer
         """
-        self.__create_container(data[Container.PREFIX],
-                                data[Container.CONFIG])
+        self.__create_container(data[Container.CONFIG])
         self.__bind_dir = self.__bindmount_folder_in_container(data[Container.HOST_PATH],
                                                                data[Container.BIND_MOUNT_DIR])
 
@@ -132,8 +128,8 @@ class Container():
         if self.__container_id is not None:
             self.__agent.ShutDownContainer(self.__container_id)
 
-    def __create_container(self, prefix, config):
-        self.__container_id = self.__agent.CreateContainer(prefix, config)
+    def __create_container(self, config):
+        self.__container_id = self.__agent.CreateContainer(config)
 
     def __bindmount_folder_in_container(self, host_path, dirname):
         return self.__agent.BindMountFolderInContainer(self.__container_id, host_path, dirname, True)

--- a/servicetest/timingprofiling/test_profiling.py
+++ b/servicetest/timingprofiling/test_profiling.py
@@ -62,7 +62,6 @@ def run_test(num_starts=3):
 
             # A basic container configuration, content is not important for this test.
             container_data = {
-                Container.PREFIX: "profiling-test-",
                 Container.CONFIG: '[{"enableWriteBuffer": false}]',
                 Container.BIND_MOUNT_DIR: "app",
                 Container.HOST_PATH: CURRENT_DIR


### PR DESCRIPTION
Refactored how the ids for the LXC containers is set.
Now the agent sets the entire ID of the container instead of
only a prefix followed by a generated string.

However, if SoftwareContainer::init() is called before the
container ID is set an ID will ge generated prefixed by "SC-".
