### PR TITLE
README: Add 'apt update' step

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ On a debian-based system, issue the following commands to build using Vagrant:
 git submodule init
 git submodule update
 
-sudo apt install virtualbox
-sudo apt install vagrant
+sudo apt update
+sudo apt install virtualbox vagrant
+
 vagrant up
 ```
 


### PR DESCRIPTION
On systems with outdated package repositories, the apt install staps
will fail without this.

Signed-off-by: Jonatan Pålsson jonatan.palsson@pelagicore.com
