### PR TITLE
examples: Unset RPATH for all examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,5 +16,7 @@
 #
 # For further information see LICENSE
 
+# Unset RPATH. This should not be needed for any example.
+set(CMAKE_INSTALL_RPATH "")
 
 add_subdirectory(simple)


### PR DESCRIPTION
The default RPATH set by a parent CMakeLists adds a superflous RPATH
which causes QA errors in some build systems (Yocto).

Signed-off-by: Jonatan Pålsson jonatan.palsson@pelagicore.com
