### PR TITLE
docs: adds examples, integrating wayland

### DIFF
--- a/doc/chapters/examples/index.rst
+++ b/doc/chapters/examples/index.rst
@@ -1,0 +1,32 @@
+
+.. _examples:
+
+SoftwareContainer examples
+**************************
+
+SoftwareContainer comes with a few examples that can be built and/or installed
+to showcase how SoftwareContainer works. All of these examples comes with a ``launch.sh`` script
+that sets up softwarecontainer-agent, configures gateways, and runs the example.
+
+.. _simple-example:
+
+Simple example
+==============
+
+The simple example needs no special configuration to run, which is to say that it does not use any
+gateways. The example code simply tries to allocate lots of memory forever. The launch script for
+this example starts the agent, bind mounts the directory in which it (and the compiled simple
+binary) exists into the container, and launches the simple binary. It runs for 30 secs, and then
+shuts down the container, and the agent.
+
+
+.. _wayland-example:
+
+Wayland example
+===============
+
+The Wayland example is not an example that is built in SoftwareContainer. Instead, it is only a
+launch script that, before it launches the agent, sets up weston (a Wayland compositor). It then
+creates a container and configures it for wayland access.  Then, it relies on the weston example
+applications being present (weston-simple-egl and weston-flower). It launches these, runs for a
+while, and shuts down.

--- a/doc/chapters/gateways/index.rst
+++ b/doc/chapters/gateways/index.rst
@@ -458,7 +458,8 @@ The Wayland Gateway is used to provide access to the hsot system Wayland server.
 Please note that the Wayland Gateway only provides access to the Wayland
 socket and sets the ``XDG_RUNTIME_DIR`` accordingly. For a Wayland
 *capability*, it is also necessary to ensure that the contained application
-has access to the graphics hardware devices and associated libraries.
+has access to the graphics hardware devices and associated libraries. Access
+to graphics hardware is **not** setup by the Wayland gateway.
 
 ID
 --

--- a/doc/chapters/integration-guidelines/index.rst
+++ b/doc/chapters/integration-guidelines/index.rst
@@ -45,3 +45,34 @@ give access to graphics hardware. Not all applications require direct access to 
 hardware, see :ref:`Wayland example <wayland-example>`. A reasonable capability for a Wayland
 application would therefore include both the Wayland gateway and a configuration of the Device Node
 gateway for any graphics hardware access needed.
+
+Example
+-------
+Here is an example manifest defining wayland access::
+
+    {
+      "capabilities": [
+        {
+          "name": "com.example.wayland-access",
+          "gateways": [
+            {
+              "id": "wayland",
+              "config": [
+                {
+                  "enabled": true
+                }
+              ]
+            },
+            {
+              "id": "devicenode",
+              "config": [
+                {
+                  "name": "/dev/dri/card0"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+

--- a/doc/chapters/integration-guidelines/index.rst
+++ b/doc/chapters/integration-guidelines/index.rst
@@ -9,7 +9,7 @@ into a platform.
 
 .. todo::
 
-    This chapter work in progress and lacks a lot of content.
+    This chapter is work in progress and lacks a lot of content.
 
 Introduction
 ============
@@ -36,3 +36,12 @@ create such a bridge on the system if it is not already there. This can be chang
 SoftwareContainer will simply fail with an error message if the bridge was not available.
 
 The selection of whether or not to create the bridge is a compile-time options given to CMake.
+
+Wayland setup
+=============
+
+In order to have applications access wayland, one needs to enable the Wayland gateway, and possibly
+give access to graphics hardware. Not all applications require direct access to the graphics
+hardware, see :ref:`Wayland example <wayland-example>`. A reasonable capability for a Wayland
+application would therefore include both the Wayland gateway and a configuration of the Device Node
+gateway for any graphics hardware access needed.

--- a/doc/chapters/service-manifests/index.rst
+++ b/doc/chapters/service-manifests/index.rst
@@ -53,11 +53,11 @@ Below is an example of a simple service manifest::
           "gateways": [
             {
               "id": "dummy-gw1",
-              "config": {}
+              "config": []
             },
             {
               "id": "dummy-gw2",
-              "config": {}
+              "config": []
             }
           ]
         },

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,7 @@ Contents:
 
     chapters/intro/*
     chapters/getting-started/*
+    chapters/examples/*
     chapters/api/*
     chapters/design/*
     chapters/configuration/*


### PR DESCRIPTION
Tells the integrator how to integrate wayland. Uses wayland example to
illustrate.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>