### PR TITLE
Changed behavior of env vars precedence

### DIFF
--- a/doc/chapters/getting-started/index.rst
+++ b/doc/chapters/getting-started/index.rst
@@ -160,7 +160,7 @@ Parameters:
  * ``commandLine`` - a string with the method to run at the method line insider the container.
  * ``workingDirectory`` - a string with a path to a directory which will be set as the working directory.
  * ``outputFile`` - a string with a path to where stdout will be directed from within the container.
- * ``env`` - a string:string dictionary with environment variables and values to be set in the container.
+ * ``env`` - a string:string dictionary with environment variables and values to be set in the container. These will override any variables with the same name previously set by the Environment gateway.
 
 The method returns the PID of the process run inside the container.
 

--- a/libsoftwarecontainer/include/container.h
+++ b/libsoftwarecontainer/include/container.h
@@ -189,6 +189,7 @@ private:
 
     bool m_enableWriteBuffer;
 
+    // All environment variables set by gateways
     EnvironmentVariables m_gatewayEnvironmentVariables;
 
     int m_shutdownTimeout = 2;

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -280,8 +280,13 @@ int Container::executeInContainerEntryFunction(void *param)
     return (*function)();
 }
 
-ReturnCode Container::executeInContainer(ContainerFunction function, pid_t *pid, const EnvironmentVariables &variables, uid_t userID,
-                                         int stdin, int stdout, int stderr)
+ReturnCode Container::executeInContainer(ContainerFunction function,
+                                         pid_t *pid,
+                                         const EnvironmentVariables &variables,
+                                         uid_t userID,
+                                         int stdin,
+                                         int stdout,
+                                         int stderr)
 {
     if (pid == nullptr) {
         log_error() << "Supplied pid argument is nullptr";
@@ -301,18 +306,26 @@ ReturnCode Container::executeInContainer(ContainerFunction function, pid_t *pid,
     options.uid = userID;
     options.gid = userID;
 
+    // List of vars to use when executing the function
     EnvironmentVariables actualVariables = variables;
 
-    // Add the variables set by the gateways
+    // Add the variables set by gateways, variables passed with the 'variables' argument
+    // will take precedence over previously set variables.
     for (auto &var : m_gatewayEnvironmentVariables) {
         if (variables.count(var.first) != 0) {
             if (m_gatewayEnvironmentVariables.at(var.first) != variables.at(var.first)) {
-                log_warning() << "Variable set by gateway overriding original variable value: "
-                              << var.first << ". values: " << var.second;
+                // Inform user that GW config will be overridden, it might be unintentionally done
+                log_info() << "Variable \""
+                           << var.first
+                           << "\" set by gateway will be overwritten with the value: \""
+                           << variables.at(var.first)
+                           << "\"";
             }
+            actualVariables[var.first] = variables.at(var.first);
+        } else {
+            // The variable was not set again, just keep the original value set by GW
+            actualVariables[var.first] = var.second;
         }
-
-        actualVariables[var.first] = var.second;
     }
 
     // prepare array of env variable strings to be set when launching the process in the container

--- a/libsoftwarecontainer/src/gateway/envgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/envgateway.cpp
@@ -62,6 +62,16 @@ ReturnCode EnvironmentGateway::readConfigElement(const json_t *element)
 
     if (m_variables.count(variableName) == 0) {
         m_variables[variableName] = variableValue;
+        if (appendMode) {
+            // The variable did not exist but the config intention was still to append,
+            // this might be a misconfiguration
+            log_info() << "Env variable \""
+                       << variableName
+                       << "\" was configured to be appended but the variable has not previously"
+                       << " been set, so it will be created. Value is set to: \""
+                       << variableValue
+                       << "\"";
+        }
     } else {
         if (appendMode) {
             m_variables[variableName] += variableValue;


### PR DESCRIPTION
Env vars set through LaunchCommand will now
take precedence over varaiables set through
the env gateway config.