### PR TITLE
Makes it possible to bind-mount read-only

### DIFF
--- a/libsoftwarecontainer/include/container.h
+++ b/libsoftwarecontainer/include/container.h
@@ -168,6 +168,8 @@ public:
 private:
     static int executeInContainerEntryFunction(void *param);
 
+    ReturnCode remountReadOnlyInContainer(const std::string &path);
+
     /**
      * @brief Helper function that rollsback the changes done in Container::create().
      */

--- a/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
@@ -287,7 +287,7 @@ TEST_F(SoftwareContainerApp, FileGatewayReadOnly) {
 
     std::string readBack = "";
     readFromFile(tempFilename1, readBack);
-    ASSERT_EQ(testData, readBack);
+    ASSERT_EQ(readBack, testData);
 
     // Remove the temp files
     ASSERT_EQ(unlink(tempFilename1), 0);
@@ -497,7 +497,7 @@ TEST_F(SoftwareContainerApp, TestUnixSocket) {
     ASSERT_TRUE(isDirectory(tempDirname));
 
     std::string pathInContainer;
-    ReturnCode result = getSc().getContainer()->bindMountFolderInContainer(tempDirname, basename(strdup(tempDirname)), pathInContainer, true);
+    ReturnCode result = getSc().getContainer()->bindMountFolderInContainer(tempDirname, basename(strdup(tempDirname)), pathInContainer, false);
     ASSERT_TRUE(isSuccess(result));
 
     char *tmp = new char[pathInContainer.size() + 8];

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -57,23 +57,23 @@ weston --backend=headless-backend.so &
 wpid=$!
 
 echo "### Running tests ###"
-GTEST_FILTER="-*FileGatewayReadOnly"
+FILTER_ARG=""
 if [ -n "$1" ]; then
-    GTEST_FILTER="$1"
+    FILTER_ARG="--gtest_filter=$1"
 fi
 
 ./agent/unit-test/softwarecontaineragenttest \
-    --gtest_filter=$GTEST_FILTER \
+    $FILTER_ARG \
     --gtest_output=xml:softwarecontaineragenttest.xml
 retval=$?
 
 ./common/unit-test/softwarecontainercommontest \
-    --gtest_filter=$GTEST_FILTER \
+    $FILTER_ARG \
     --gtest_output=xml:softwarecontainercommontest.xml
 retval=$(($retval+$?))
 
 ./libsoftwarecontainer/unit-test/softwarecontainerlibtest \
-    --gtest_filter=$GTEST_FILTER \
+    $FILTER_ARG \
     --gtest_output=xml:softwarecontainerlibtest.xml
 retval=$(($retval+$?))
 


### PR DESCRIPTION
Bind-mounting read-only into the container now works, by re-mounting
from inside the container.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>