### PR TITLE
tests for common no longer fail with memory issues

### DIFF
--- a/common/unit-test/CMakeLists.txt
+++ b/common/unit-test/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 include(AddGTestTest)
 
-set(TEST_LIBRARY_DEPENDENCIES 
+set(TEST_LIBRARY_DEPENDENCIES
     ${DBusCpp_LIBRARIES}
     ${Glibmm_LIBRARIES}
     ${LXC_LIBRARIES}
@@ -26,13 +26,12 @@ set(TEST_LIBRARY_DEPENDENCIES
     ${IVILogging_LIBRARIES}
     softwarecontainerlib
 )
+
 include_directories(${SOFTWARECONTAINER_COMMON_DIR})
 
 set(TEST_FILES
     softwarecontainer-common_unittest.cpp
     recursivecopy_unittest.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../softwarecontainer-common.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../recursivecopy.cpp
     main.cpp
 )
 


### PR DESCRIPTION
The unit tests for the common library fails with invalid pointer
or double free (depending on run). This fixes that issue.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>