### PR TITLE
Minor fix in service-test framework

### DIFF
--- a/servicetest/capabilities/test_caps.py
+++ b/servicetest/capabilities/test_caps.py
@@ -37,7 +37,8 @@ def logfile_path():
 DATA = {
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
-    Container.HOST_PATH: CURRENT_DIR
+    Container.HOST_PATH: CURRENT_DIR,
+    Container.READONLY: False
 }
 
 

--- a/servicetest/dbus/test_dbus.py
+++ b/servicetest/dbus/test_dbus.py
@@ -45,7 +45,8 @@ HOST_PATH = os.path.dirname(os.path.abspath(__file__))
 DATA = {
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
-    Container.HOST_PATH: HOST_PATH
+    Container.HOST_PATH: HOST_PATH,
+    Container.READONLY: False
 }
 
 # Simple gateway config when something just needs to be passed.

--- a/servicetest/environment/test_environment.py
+++ b/servicetest/environment/test_environment.py
@@ -79,7 +79,8 @@ HOST_PATH = os.path.dirname(os.path.abspath(__file__))
 DATA = {
     Container.CONFIG: "[{\"enableWriteBuffer\": false}]",
     Container.BIND_MOUNT_DIR: "app",
-    Container.HOST_PATH: HOST_PATH
+    Container.HOST_PATH: HOST_PATH,
+    Container.READONLY: False
 }
 
 

--- a/servicetest/filesystem/test_filesystem.py
+++ b/servicetest/filesystem/test_filesystem.py
@@ -37,7 +37,8 @@ def logfile_path():
 DATA = {
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
-    Container.HOST_PATH: CURRENT_DIR
+    Container.HOST_PATH: CURRENT_DIR,
+    Container.READONLY: False
 }
 
 @pytest.mark.usefixtures("dbus_launch", "agent", "assert_no_proxy")

--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -50,6 +50,7 @@ class Container():
     CONFIG = "config"
     BIND_MOUNT_DIR = "bind-mount-dir"
     HOST_PATH = "host-path"
+    READONLY = False
 
     def __init__(self):
         bus = dbus.SystemBus()
@@ -109,7 +110,8 @@ class Container():
             {
                 Container.CONFIG: "{enableWriteBuffer: false}",
                 Container.HOST_PATH: my_path_string_variable,
-                Container.BIND_MOUNT_DIR: "app"
+                Container.BIND_MOUNT_DIR: "app",
+                Container.READONLY: True
             }
 
             The values in the dict are passed as arguments to the D-Bus methods on SoftwareContainerAgent.
@@ -117,11 +119,12 @@ class Container():
             Container.CONFIG - argument to SoftwareContainerAgent::CreateContainer
             Container.HOST_PATH - second argument to SoftwareContainerAgent::BindMountFolderInContainer
             Container.BIND_MOUNT_DIR - third argument to SoftwareContainerAgent::BindMountFolderInContainer
+            Container.READONLY - fourth argument to SoftwareContainerAgent::BindMountFolderInContainer
         """
         self.__create_container(data[Container.CONFIG])
         self.__bind_dir = self.__bindmount_folder_in_container(data[Container.HOST_PATH],
                                                                data[Container.BIND_MOUNT_DIR],
-                                                               readonly=False)
+                                                               data[Container.READONLY])
 
     def terminate(self):
         """ Perform teardown of container created by call to 'start'
@@ -132,7 +135,7 @@ class Container():
     def __create_container(self, config):
         self.__container_id = self.__agent.CreateContainer(config)
 
-    def __bindmount_folder_in_container(self, host_path, dirname, readonly=True):
+    def __bindmount_folder_in_container(self, host_path, dirname, readonly):
         return self.__agent.BindMountFolderInContainer(self.__container_id, host_path, dirname, readonly)
 
 

--- a/servicetest/timingprofiling/test_profiling.py
+++ b/servicetest/timingprofiling/test_profiling.py
@@ -64,7 +64,8 @@ def run_test(num_starts=3):
             container_data = {
                 Container.CONFIG: '[{"enableWriteBuffer": false}]',
                 Container.BIND_MOUNT_DIR: "app",
-                Container.HOST_PATH: CURRENT_DIR
+                Container.HOST_PATH: CURRENT_DIR,
+                Container.READONLY: False
             }
             container.start(container_data)
 


### PR DESCRIPTION
The "data" dict passed by tests to the Container
helper now carries the readonly flag as well.