### PR TITLE
Enables building examples in Jenkinsfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ option(ENABLE_CGROUPSGATEWAY "Enables cgroups gateway" ON)
 option(ENABLE_SYSTEMD "Installs systemd service files" ON)
 option(ENABLE_TEST "Enables unit testing" ON)
 option(ENABLE_PROFILING "Enables profiling support in the application" OFF)
-option(ENABLE_COVERAGE "Enable building and installation of examples" OFF)
+option(ENABLE_COVERAGE "Enable coverage support in the build" OFF)
 option(ENABLE_EXAMPLES "Enable building and installation of examples" OFF)
 option(CREATE_BRIDGE "SoftwareContainer will create network bridge if missing" ON)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,10 @@ node {
     try {
         // Store the directory we are executed in as our workspace.
         // These are the build parameters we want to use
-        String buildParams = "-DENABLE_TEST=ON -DENABLE_COVERAGE=1 "
-        buildParams       += "-DENABLE_USER_DOC=1 -DENABLE_API_DOC=1 "
-        buildParams       += "-DENABLE_SYSTEMD=1 -DENABLE_PROFILING=1 "
-        buildParams       += "-DCMAKE_INSTALL_PREFIX=/usr"
+        String buildParams = "-DENABLE_TEST=ON -DENABLE_COVERAGE=ON "
+        buildParams       += "-DENABLE_USER_DOC=ON -DENABLE_API_DOC=ON "
+        buildParams       += "-DENABLE_SYSTEMD=ON -DENABLE_PROFILING=ON "
+        buildParams       += "-DENABLE_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=/usr"
 
         stage 'Download'
             // Checkout the git repository and refspec pointed to by jenkins


### PR DESCRIPTION
Also fixes a typo in the CMakeLists.txt regarding description
of examples.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>