### PR TITLE
Make the service tests fail + store their results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ node {
             // Store the unit test results and graph it
             // NOTE: the paths can not be absolute, it will not be accepted for some reason
             step([$class: 'JUnitResultArchiver', testResults: 'build/*test.xml'])
+            step([$class: 'JUnitResultArchiver', testResults: 'servicetest/*test.xml'])
 
     }
 

--- a/servicetest/run-tests.sh
+++ b/servicetest/run-tests.sh
@@ -18,14 +18,19 @@
 # For further information see LICENSE
 
 
-DIRECTORIES=(dbus timingprofiling filesystem capabilities environment suspend)
+DIRECTORIES=(suspend dbus timingprofiling filesystem capabilities environment)
 
+# We want to exit with bad status in case some test fail. Mostly so that any
+# CI system will notice that not everything was good.
+EXITSTATUS=0
 for DIR in ${DIRECTORIES[@]}; do
         echo "Running service tests in $DIR"
         pushd $DIR > /dev/null
         py.test -v --junit-xml=../${DIR}_test.xml
+        (( EXITSTATUS += $? ))
         # Sleep to allow some time for teardown in previous suite
         # to have full effect before we run the next suite
         sleep 1
         popd > /dev/null
 done
+exit $EXITSTATUS

--- a/servicetest/suspend/test_suspend.py
+++ b/servicetest/suspend/test_suspend.py
@@ -38,7 +38,8 @@ def logfile_path():
 DATA = {
     Container.CONFIG: '[{"enableWriteBuffer": false}]',
     Container.BIND_MOUNT_DIR: "app",
-    Container.HOST_PATH: CURRENT_DIR
+    Container.HOST_PATH: CURRENT_DIR,
+    Container.READONLY: False
 }
 
 def isFileGrowing(filename):
@@ -106,11 +107,12 @@ class TestSuspend(object):
             when the container is suspended, and that it is resuming execution
             when the container is resumed.
         """
+
+        filename = "yes_output.log"
         try:
             sc = Container()
             sc.start(DATA)
 
-            filename = "yes_output.log"
 
             launched = sc.launch_command("yes", stdout=filename)
             assert launched != -1


### PR DESCRIPTION
The suspend test was not properly configured for read-only bind mount,
that is also fixed.

The run script for service tests now exit with exit status equal to
the sum of all exit statuses of the tests (so if one fail it will at
least be 1 or higher).

The Jenkinsfile is instructed to save the JUnit XML files from the service
tests.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>