### PR TITLE
Use the JSONParser statically, don't inherit.

### DIFF
--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -107,7 +107,7 @@ bool SoftwareContainerAgent::checkContainer(ContainerID containerID, SoftwareCon
 ReturnCode SoftwareContainerAgent::readConfigElement(const json_t *element)
 {
     bool wo = false;
-    if(!read(element, "enableWriteBuffer", wo)) {
+    if(!JSONParser::read(element, "enableWriteBuffer", wo)) {
         log_debug() << "enableWriteBuffer not found";
     }
 

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -57,7 +57,7 @@
  */
 namespace softwarecontainer {
 
-class SoftwareContainerAgent : protected softwarecontainer::JSONParser
+class SoftwareContainerAgent
 {
     LOG_DECLARE_CLASS_CONTEXT("SCA", "SoftwareContainerAgent");
     typedef std::unique_ptr<SoftwareContainer> SoftwareContainerPtr;

--- a/common/jsonparser.h
+++ b/common/jsonparser.h
@@ -29,7 +29,7 @@ namespace softwarecontainer {
      * This class provides convenience functions that handles commonly used operations
      * using the Janssson JSON parser.
      */
-    class JSONParser {
+    class JSONParser final {
         LOG_DECLARE_CLASS_CONTEXT("JSON", "JSONParser");
 
     public:

--- a/libsoftwarecontainer/include/gateway.h
+++ b/libsoftwarecontainer/include/gateway.h
@@ -38,7 +38,7 @@
  * The complete gateway config is passed as a JSON array and all
  * gateways then provide their specific parsing of the items in the array.
  */
-class Gateway: protected softwarecontainer::JSONParser
+class Gateway
 {
     LOG_DECLARE_CLASS_CONTEXT("GATE", "Gateway");
 

--- a/libsoftwarecontainer/src/gateway/cgroupsgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/cgroupsgateway.cpp
@@ -36,12 +36,12 @@ ReturnCode CgroupsGateway::readConfigElement(const json_t *element)
     std::string settingKey;
     std::string settingValue;
 
-    if (!read(element, "setting", settingKey)) {
+    if (!JSONParser::read(element, "setting", settingKey)) {
         log_error() << "Key \"setting\" either not a string or not in json configuration";
         return ReturnCode::FAILURE;
     }
 
-    if (!read(element, "value", settingValue)) {
+    if (!JSONParser::read(element, "value", settingValue)) {
         log_error() << "Key \"value\" either not a string or not in json configuration";
         return ReturnCode::FAILURE;
     }

--- a/libsoftwarecontainer/src/gateway/devicenodegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenodegateway.cpp
@@ -33,14 +33,14 @@ ReturnCode DeviceNodeGateway::readConfigElement(const json_t *element)
 {
     DeviceNodeGateway::Device dev;
 
-    if (!read(element, "name", dev.name)) {
+    if (!JSONParser::read(element, "name", dev.name)) {
         log_error() << "Key \"name\" missing or not a string in json configuration";
         return ReturnCode::FAILURE;
     }
 
-    read(element, "major", dev.major);
-    read(element, "minor", dev.minor);
-    read(element, "mode",  dev.mode);
+    JSONParser::read(element, "major", dev.major);
+    JSONParser::read(element, "minor", dev.minor);
+    JSONParser::read(element, "mode",  dev.mode);
 
     const bool majorSpecified = dev.major.length() > 0;
     const bool minorSpecified = dev.minor.length() > 0;

--- a/libsoftwarecontainer/src/gateway/envgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/envgateway.cpp
@@ -37,7 +37,7 @@ ReturnCode EnvironmentGateway::readConfigElement(const json_t *element)
     std::string variableName;
     std::string variableValue;
 
-    if (!read(element, "name", variableName)) {
+    if (!JSONParser::read(element, "name", variableName)) {
         log_error() << "Key \"name\" missing or not a string in json configuration";
         return ReturnCode::FAILURE;
     }
@@ -47,7 +47,7 @@ ReturnCode EnvironmentGateway::readConfigElement(const json_t *element)
         return ReturnCode::FAILURE;
     }
 
-    if (!read(element, "value", variableValue)) {
+    if (!JSONParser::read(element, "value", variableValue)) {
         log_error() << "Key \"value\" missing or not a string in json configuration";
         return ReturnCode::FAILURE;
     }
@@ -58,7 +58,7 @@ ReturnCode EnvironmentGateway::readConfigElement(const json_t *element)
     }
 
     bool appendMode = false;
-    read(element, "append", appendMode); // This key is optional
+    JSONParser::read(element, "append", appendMode); // This key is optional
 
     if (m_variables.count(variableName) == 0) {
         m_variables[variableName] = variableValue;

--- a/libsoftwarecontainer/src/gateway/filegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/filegateway.cpp
@@ -32,13 +32,13 @@ ReturnCode FileGateway::readConfigElement(const json_t *element)
 {
     FileSetting setting;
 
-    read(element, "path-host", setting.pathInHost);
-    read(element, "path-container", setting.pathInContainer);
-    read(element, "env-var-name", setting.envVarName);
-    read(element, "env-var-prefix", setting.envVarPrefix);
-    read(element, "env-var-suffix", setting.envVarSuffix);
-    read(element, "create-symlink", setting.createSymlinkInContainer);
-    read(element, "read-only", setting.readOnly);
+    JSONParser::read(element, "path-host", setting.pathInHost);
+    JSONParser::read(element, "path-container", setting.pathInContainer);
+    JSONParser::read(element, "env-var-name", setting.envVarName);
+    JSONParser::read(element, "env-var-prefix", setting.envVarPrefix);
+    JSONParser::read(element, "env-var-suffix", setting.envVarSuffix);
+    JSONParser::read(element, "create-symlink", setting.createSymlinkInContainer);
+    JSONParser::read(element, "read-only", setting.readOnly);
 
     if (setting.pathInHost.size() == 0) {
         log_error() << "FileGateway config is lacking 'path-host' setting";

--- a/libsoftwarecontainer/src/gateway/networkgatewayparser.cpp
+++ b/libsoftwarecontainer/src/gateway/networkgatewayparser.cpp
@@ -21,7 +21,7 @@
 ReturnCode NetworkGatewayParser::parseNetworkGatewayConfiguration(const json_t *element, IPTableEntry &e)
 {
     std::string chain;
-    if (!read(element, "type", chain)) {
+    if (!JSONParser::read(element, "type", chain)) {
         log_error() << "No type specified in network config.";
         return ReturnCode::FAILURE;
     }
@@ -36,7 +36,7 @@ ReturnCode NetworkGatewayParser::parseNetworkGatewayConfiguration(const json_t *
     }
 
     int p;
-    if (!read(element, "priority", p)) {
+    if (!JSONParser::read(element, "priority", p)) {
         log_error() << "No priority specified in network config.";
         return ReturnCode::FAILURE;
     }
@@ -74,7 +74,7 @@ ReturnCode NetworkGatewayParser::parseNetworkGatewayConfiguration(const json_t *
     }
 
     std::string readTarget;
-    if (!read(element, "default", readTarget)) {
+    if (!JSONParser::read(element, "default", readTarget)) {
         log_error() << "No default target specified or default target is not a string.";
         return ReturnCode::FAILURE;
     }
@@ -94,7 +94,7 @@ ReturnCode NetworkGatewayParser::parseRule(const json_t *element, std::vector<IP
 {
     IPTableEntry::Rule r;
     std::string target;
-    if (!read(element, "target", target)) {
+    if (!JSONParser::read(element, "target", target)) {
         log_error() << "Target not specified in the network config";
         return ReturnCode::FAILURE;
     }
@@ -105,7 +105,7 @@ ReturnCode NetworkGatewayParser::parseRule(const json_t *element, std::vector<IP
         return ReturnCode::FAILURE;
     }
 
-    if (!read(element, "host", r.host)) {
+    if (!JSONParser::read(element, "host", r.host)) {
         log_error() << "Host not specified in the network config.";
         return ReturnCode::FAILURE;
     }

--- a/libsoftwarecontainer/src/gateway/networkgatewayparser.h
+++ b/libsoftwarecontainer/src/gateway/networkgatewayparser.h
@@ -24,7 +24,7 @@
 #include "jsonparser.h"
 
 
-class NetworkGatewayParser : protected softwarecontainer::JSONParser
+class NetworkGatewayParser
 {
     LOG_DECLARE_CLASS_CONTEXT("NETP", "Network Gateway Parser");
 public :

--- a/libsoftwarecontainer/src/gateway/pulsegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.cpp
@@ -33,7 +33,7 @@ PulseGateway::~PulseGateway()
 
 ReturnCode PulseGateway::readConfigElement(const json_t *element)
 {
-    if (!read(element, "audio", m_enableAudio)) {
+    if (!JSONParser::read(element, "audio", m_enableAudio)) {
         log_error() << "Either \"audio\" key is missing, or not a bool in json configuration";
         return ReturnCode::FAILURE;
     }

--- a/libsoftwarecontainer/src/gateway/waylandgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.cpp
@@ -40,7 +40,7 @@ WaylandGateway::~WaylandGateway()
 
 ReturnCode WaylandGateway::readConfigElement(const json_t *element)
 {
-    if (!read(element, ENABLED_FIELD, m_enabled)) {
+    if (!JSONParser::read(element, ENABLED_FIELD, m_enabled)) {
         log_error() << "Key " << ENABLED_FIELD << " missing or not bool in json configuration";
         return ReturnCode::FAILURE;
     }


### PR DESCRIPTION
All functions in the JSONParser are static, now all uses of it
is also static, removing the inheritance of the class from various
places.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>