### PR TITLE
Sets shutdown timeout to 1 sec, haltsignal to SIGKILL

### DIFF
--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -33,7 +33,7 @@ void usage(const char *argv0)
     printf("  -p, --preload <num>     : Number of containers to preload, defaults to 0\n");
     printf("  -u, --user <uid>        : Default user id to be used when starting processes in the container, defaults to 0\n");
     printf("  -s, --shutdown <bool>   : If false, containers will not be shutdown on exit. Useful for debugging. Defaults to true\n");
-    printf("  -t, --timeout <seconds> : Timeout in seconds to wait for containers to shutdown, defaults to 2\n");
+    printf("  -t, --timeout <seconds> : Timeout in seconds to wait for containers to shutdown, defaults to 1\n");
     printf("  -m, --manifest <path>   : Path to a file or directory where service manifest(s) exist, defaults to \"\"\n");
     printf("  -b, --session-bus       : Use the session bus instead of the system bus\n");
     printf("  -h, --help              : Prints this help message and exits.\n");
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     int preloadCount = 0;
     int userID = 0;
     bool shutdownContainers = true;
-    int timeout = 2;
+    int timeout = 1;
     std::string servicemanifest = "";
     bool useSystemBus = true;
 

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -33,7 +33,7 @@ public:
     Glib::RefPtr<Glib::MainContext> m_context = Glib::MainContext::get_default();
     int m_preloadCount = 0;
     bool m_shutdownContainers = true;
-    int m_shutdownTimeout = 2;
+    int m_shutdownTimeout = 1;
     std::shared_ptr<Workspace> workspace;
     std::string m_configPath ="";
 

--- a/libsoftwarecontainer/include/container.h
+++ b/libsoftwarecontainer/include/container.h
@@ -74,12 +74,11 @@ public:
      * @param enableWriteBuffer Enable RAM write buffers on top of rootfs
      * @param shutdownTimeout Timeout for shutdown of container.
      */
-    Container(
-            const std::string id
+    Container(const std::string id
             , const std::string &configFile
             , const std::string &containerRoot
             , bool enableWriteBuffer = false
-            , int shutdownTimeout = 2);
+            , int shutdownTimeout = 1);
 
     ~Container();
 
@@ -221,7 +220,7 @@ private:
     // All environment variables set by gateways
     EnvironmentVariables m_gatewayEnvironmentVariables;
 
-    int m_shutdownTimeout = 2;
+    int m_shutdownTimeout = 1;
 
     enum class ContainerState : unsigned int {
         DEFAULT = 0,

--- a/libsoftwarecontainer/include/workspace.h
+++ b/libsoftwarecontainer/include/workspace.h
@@ -45,7 +45,7 @@ public:
     Workspace(bool enableWriteBuffer = false,
               const std::string &containerRootDir = SOFTWARECONTAINER_DEFAULT_WORKSPACE,
               const std::string &containerConfigPath = SOFTWARECONTAINER_DEFAULT_CONFIG,
-              unsigned int containerShutdownTimeout = 2);
+              unsigned int containerShutdownTimeout = 1);
 
     ~Workspace();
 

--- a/libsoftwarecontainer/softwarecontainer.conf.in
+++ b/libsoftwarecontainer/softwarecontainer.conf.in
@@ -4,6 +4,11 @@ lxc.autodev = 1
 lxc.tty = 1
 lxc.pts = 1
 
+#
+# TODO: Remove this when we get the shutdown timeout issue fixed.
+#
+lxc.haltsignal = SIGKILL
+
 @NETWORK_LXC_CONF@
 
 lxc.mount.entry = /sbin sbin none ro,bind 0 0

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -57,8 +57,11 @@ void Container::init_lxc()
     }
 }
 
-Container::Container(const std::string id, const std::string &configFile,
-        const std::string &containerRoot, bool enableWriteBuffer, int shutdownTimeout) :
+Container::Container(const std::string id,
+                     const std::string &configFile,
+                     const std::string &containerRoot,
+                     bool enableWriteBuffer,
+                     int shutdownTimeout) :
     m_configFile(configFile),
     m_id(id),
     m_containerRoot(containerRoot),


### PR DESCRIPTION
This sets the shutdown signal for containers to 1 second. At the same
time, that will not be applied directly, since this also sets the halt
signal to SIGKILL.

The background for this is that we have a bug where containers always
timeout when shutting down, leading to us calling stop() on the LXC
container, which in turn sends SIGKILL.

When the timeout bug is fixed, we should remove the haltsignal
directive completely, and then 1 second should still be plenty of time
to shut down.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>