### PR TITLE
Changes the name of SC so-file and fix RPATH settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,22 +121,16 @@ endif()
 # RPATH options
 #
 
-# use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+# Use RPATH only if we're not installing to a system directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" IS_SYSTEM_DIR)
+if(${IS_SYSTEM_DIR} STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
 
-# when building, don't use the install RPATH already (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
-
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-# the RPATH to be used when installing, but only if it's not a system directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
-if("${isSystemDir}" STREQUAL "-1")
-   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
-endif("${isSystemDir}" STREQUAL "-1")
+#
+# Config options
+#
 
 SET(SYS_CONFIG_DIR ${CMAKE_INSTALL_FULL_SYSCONFDIR})
 SET(LXC_TEMPLATE_DIR ${CMAKE_INSTALL_FULL_DATAROOTDIR}/softwarecontainer/lxc-templates)
@@ -152,6 +146,9 @@ if(ENABLE_PROFILING)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPROFILING_ENABLED=1")
 endif()
 
+#
+# Optionally include testing and coverage
+#
 if(ENABLE_TEST)
     include(AddGMock)
     add_gmock()
@@ -229,17 +226,15 @@ add_definitions(-DLXC_CONFIG_PATH_TESTING="${LXC_CONFIG_PATH}")
 add_definitions(-DSERVICE_MANIFEST_DIR_TESTING="${SERVICE_MANIFEST_DIR}")
 add_definitions(-DDEFAULT_SERVICE_MANIFEST_DIR_TESTING="${DEFAULT_SERVICE_MANIFEST_DIR}")
 
-
 #
 # Add all sub-projects
 #
 add_subdirectory(common)
 add_subdirectory(libsoftwarecontainer)
-
 add_subdirectory(agent)
+add_subdirectory(doc)
 
 if (ENABLE_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-add_subdirectory(doc)

--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(softwarecontainer-agent
     ${LXC_LIBRARIES}
     ${Jansson_LIBRARIES}
     ${IVILogging_LIBRARIES}
-    softwarecontainerlib
+    softwarecontainer
     softwarecontainercommon
 )
 

--- a/agent/unit-test/CMakeLists.txt
+++ b/agent/unit-test/CMakeLists.txt
@@ -27,7 +27,7 @@ set(AGENT_TEST_LIBRARY_DEPENDENCIES
     ${LXC_LIBRARIES}
     ${Jansson_LIBRARIES}
     ${IVILogging_LIBRARIES}
-    softwarecontainerlib
+    softwarecontainer
     softwarecontainercommon
 )
 
@@ -35,7 +35,7 @@ set(CONFIGSTORE_TEST_LIBRARY_DEPENDENCIES
     ${Glibmm_LIBRARIES}
     ${Jansson_LIBRARIES}
     ${IVILogging_LIBRARIES}
-    softwarecontainerlib
+    softwarecontainer
     softwarecontainercommon
 )
 

--- a/libsoftwarecontainer/softwarecontainer.pc.in
+++ b/libsoftwarecontainer/softwarecontainer.pc.in
@@ -7,5 +7,5 @@ Name: softwarecontainer
 Description: SoftwareContainer
 Version: @VERSION@
 Requires: lxc glibmm-2.4 ivi-logging dbus-c++-glib-1 jansson
-Libs: -lsoftwarecontainerlib -lsoftwarecontainercommon @DEVELOPMENT_LIBRARY_PATH@ -L${libdir} 
+Libs: -lsoftwarecontainer -lsoftwarecontainercommon @DEVELOPMENT_LIBRARY_PATH@ -L${libdir} 
 Cflags: -std=c++11 @DEVELOPMENT_INCLUDE_PATH@ -I${includedir}/softwarecontainer -I${libdir}/softwarecontainer

--- a/libsoftwarecontainer/src/CMakeLists.txt
+++ b/libsoftwarecontainer/src/CMakeLists.txt
@@ -26,7 +26,7 @@ add_definitions(${GATEWAY_DEFINITIONS})
 set(JOB_SOURCES "")
 add_subdirectory(jobs)
 
-add_library(softwarecontainerlib SHARED
+add_library(softwarecontainer SHARED
     container.cpp
     softwarecontainer.cpp
     workspace.cpp
@@ -37,7 +37,7 @@ add_library(softwarecontainerlib SHARED
     ${JOB_SOURCES}
 )
 
-TARGET_LINK_LIBRARIES(softwarecontainerlib
+TARGET_LINK_LIBRARIES(softwarecontainer
     softwarecontainercommon
     ${DBusCpp_LIBRARIES}
     ${Glibmm_LIBRARIES}
@@ -47,5 +47,5 @@ TARGET_LINK_LIBRARIES(softwarecontainerlib
 
 include_directories(${LIBSOFTWARECONTAINER_DIR}/include)
 
-install(TARGETS softwarecontainerlib DESTINATION lib)
-set_target_properties(softwarecontainerlib PROPERTIES VERSION ${VERSION} SOVERSION ${${PROJECT_NAME}_MAJOR_VERSION})
+install(TARGETS softwarecontainer DESTINATION lib)
+set_target_properties(softwarecontainer PROPERTIES VERSION ${VERSION} SOVERSION ${${PROJECT_NAME}_MAJOR_VERSION})

--- a/libsoftwarecontainer/unit-test/CMakeLists.txt
+++ b/libsoftwarecontainer/unit-test/CMakeLists.txt
@@ -27,7 +27,7 @@ set(TEST_LIBRARY_DEPENDENCIES
     ${LXC_LIBRARIES}
     ${Jansson_LIBRARIES}
     ${IVILogging_LIBRARIES}
-    softwarecontainerlib
+    softwarecontainer
 )
 include_directories(${LIBSOFTWARECONTAINER_DIR}/include)
 


### PR DESCRIPTION
The name of the so file is no longer libsoftwarecontainerlib.so
because the name of the CMake target has changed.

The RPATH settings have also been trimmed down and the values
that are the default values have been removed.

Signed-off-by: Tobias Olausson <tobsan@gmail.com>