### PR TITLE
Uses Glib::getenv which provides nicer error check

### DIFF
--- a/agent/unit-test/main.cpp
+++ b/agent/unit-test/main.cpp
@@ -30,7 +30,9 @@ LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context")
 
 int main(int argc, char * *argv)
 {
-    if (!std::getenv("LOG_OUTPUT")) {
+    bool logOutput = false;
+    Glib::getenv("LOG_OUTPUT", logOutput);
+    if (!logOutput) {
         // Silence the logger
         logging::ConsoleLogContext::setGlobalLogLevel(logging::LogLevel::None);
     }

--- a/common/unit-test/main.cpp
+++ b/common/unit-test/main.cpp
@@ -30,7 +30,9 @@ LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context")
 
 int main(int argc, char * *argv)
 {
-    if (!std::getenv("LOG_OUTPUT")) {
+    bool logOutput = false;
+    Glib::getenv("LOG_OUTPUT", logOutput);
+    if (!logOutput) {
         // Silence the logger
         logging::ConsoleLogContext::setGlobalLogLevel(logging::LogLevel::None);
     }

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -145,7 +145,7 @@ ReturnCode Container::create()
     }
 
     setenv("GATEWAY_DIR", gatewaysDir().c_str(), true);
-    log_debug() << "GATEWAY_DIR : " << getenv("GATEWAY_DIR");
+    log_debug() << "GATEWAY_DIR : " << Glib::getenv("GATEWAY_DIR");
 
     auto configFile = m_configFile.c_str();
     log_debug() << "Config file : " << configFile;

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgateway.cpp
@@ -72,7 +72,11 @@ bool DBusGateway::activateGateway()
 
     // Give the dbus-proxy access to the real dbus bus address.
     std::vector<std::string> envVec;
-    if (char *envValue = getenv(variable.c_str())) {
+
+    bool hasEnvVar = false;
+    std::string envValue = Glib::getenv(variable, hasEnvVar);
+
+    if (hasEnvVar) {
         envVec.push_back(variable + "=" + envValue);
     } else if (m_type == SessionProxy) {
         log_error() << "Using DBus gateway in session mode"

--- a/libsoftwarecontainer/src/gateway/pulsegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.cpp
@@ -46,11 +46,12 @@ bool PulseGateway::activateGateway()
         log_debug() << "Audio will be disabled";
         return true;
     }
-
     log_debug() << "Audio will be enabled";
-    const char *dir = getenv(PULSE_AUDIO_SERVER_ENVIRONMENT_VARIABLE_NAME);
 
-    if (dir == nullptr) {
+    bool hasPulse = false;
+    std::string dir = Glib::getenv(PULSE_AUDIO_SERVER_ENVIRONMENT_VARIABLE_NAME, hasPulse);
+
+    if (!hasPulse) {
         log_error() << "Should enable pulseaudio gateway, but "
                     << std::string(PULSE_AUDIO_SERVER_ENVIRONMENT_VARIABLE_NAME) << " is not defined";
         return false;

--- a/libsoftwarecontainer/src/gateway/waylandgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.cpp
@@ -62,8 +62,9 @@ bool WaylandGateway::activateGateway()
         return true;
     }
 
-    const char *dir = getenv(WAYLAND_RUNTIME_DIR_VARIABLE_NAME);
-    if (dir == nullptr) {
+    bool hasWayland = false;
+    std::string dir = Glib::getenv(WAYLAND_RUNTIME_DIR_VARIABLE_NAME, hasWayland);
+    if (!hasWayland) {
         log_error() << "Should enable wayland gateway, but " << WAYLAND_RUNTIME_DIR_VARIABLE_NAME << " is not defined";
         return false;
     }

--- a/libsoftwarecontainer/unit-test/main.cpp
+++ b/libsoftwarecontainer/unit-test/main.cpp
@@ -30,7 +30,9 @@ LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context")
 
 int main(int argc, char * *argv)
 {
-    if (!std::getenv("LOG_OUTPUT")) {
+    bool logOutput = false;
+    Glib::getenv("LOG_OUTPUT", logOutput);
+    if (!logOutput) {
         // Silence the logger
         logging::ConsoleLogContext::setGlobalLogLevel(logging::LogLevel::None);
     }

--- a/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
@@ -72,16 +72,17 @@ TEST_F(SoftwareContainerApp, TestWaylandWhitelist) {
         bool ERROR = 1;
         bool SUCCESS = 0;
 
-        const char *waylandDir = getenv("XDG_RUNTIME_DIR");
-        log_debug() << "Wayland dir : " << waylandDir;
-        if (waylandDir == nullptr) {
+        bool hasWayland = false;
+        std::string waylandDir = Glib::getenv(WaylandGateway::WAYLAND_RUNTIME_DIR_VARIABLE_NAME,
+                                              hasWayland);
+        if (!hasWayland) {
+            log_error() << "No wayland dir";
             return ERROR;
         }
-
+        log_debug() << "Wayland dir : " << waylandDir;
         std::string socketPath = StringBuilder() << waylandDir << "/"
                                                  << WaylandGateway::SOCKET_FILE_NAME;
         log_debug() << "isSocket : " << socketPath << " " << isSocket(socketPath);
-
         if ( !isSocket(socketPath) ) {
             return ERROR;
         }
@@ -183,7 +184,9 @@ TEST_F(SoftwareContainerApp, CommonFunctions) {
 
 TEST_F(SoftwareContainerApp, EnvVarsSet) {
     FunctionJob job(getSc(), [&] () {
-        return getenv("TESTVAR") != NULL ? 0 : 1;
+        bool hasTestVar = false;
+        Glib::getenv("TESTVAR", hasTestVar);
+        return hasTestVar ? 0 : 1;
     });
     job.setEnvironmentVariable("TESTVAR","YES");
     job.start();


### PR DESCRIPTION
Glibmm provides a higher-level function to check environment variables,
which also can set a bool if they are set or not, letting us get rid of
all those nullptr or NULL comparisons.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>