### PR TITLE
Various code cleanup, emphasis on includes

### DIFF
--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -52,6 +52,7 @@ int signalHandler(void *data) {
  */
 DBus::Connection getBusConnection(bool useSessionBus)
 {
+    static constexpr const char *AGENT_BUS_NAME = "com.pelagicore.SoftwareContainerAgent";
     std::string busStr = useSessionBus ? "session" : "system";
     try {
         DBus::Connection bus = useSessionBus ? DBus::Connection::SessionBus()
@@ -228,6 +229,7 @@ int main(int argc, char **argv)
     Config config(std::move(loader), std::move(defaults), stringOptions, intOptions, boolOptions);
 
     try {
+        static constexpr const char *AGENT_OBJECT_PATH = "/com/pelagicore/SoftwareContainerAgent";
         DBus::Connection connection = getBusConnection(useSessionBus);
         SoftwareContainerAgent agent(mainContext, config);
         std::unique_ptr<SoftwareContainerAgentAdaptor> adaptor =

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -33,8 +33,6 @@
     #include <dbus-c++/glib-integration.h>
 #pragma GCC diagnostic pop
 
-#include <getopt.h>
-
 #include <ivi-profiling.h>
 
 #pragma GCC diagnostic push
@@ -52,12 +50,13 @@
 #include "commandjob.h"
 #include <queue>
 
-
 /**
  * @class softwarecontainer::SoftwareContainerAgent
  * @brief A wrapper class
  */
 namespace softwarecontainer {
+
+static constexpr ContainerID INVALID_CONTAINER_ID = -1;
 
 class SoftwareContainerAgent
 {

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -27,6 +27,7 @@ set(HEADERS
     mountcleanuphandler.h
     filetoolkitwithundo.h
     gatewayconfig.h
+    signalconnectionshandler.h
 )
 
 add_library(softwarecontainercommon SHARED
@@ -39,6 +40,7 @@ add_library(softwarecontainercommon SHARED
     softwarecontainer-common.cpp
     recursivecopy.cpp
     gatewayconfig.cpp
+    signalconnectionshandler.cpp
 )
 
 install(FILES ${HEADERS} DESTINATION include/softwarecontainer)

--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -18,6 +18,9 @@
  * For further information see LICENSE
  */
 
+#include <sys/stat.h>
+#include <sys/mount.h>
+
 #include "filetoolkitwithundo.h"
 
 #include "directorycleanuphandler.h"
@@ -173,9 +176,9 @@ ReturnCode FileToolkitWithUndo::overlayMount(
         return ReturnCode::FAILURE;
     }
 
-    std::string mountoptions = StringBuilder() << "lowerdir=" << lower
-                                               << ",upperdir=" << upper
-                                               << ",workdir=" << work;
+    std::string mountoptions = logging::StringBuilder() << "lowerdir=" << lower
+                                                        << ",upperdir=" << upper
+                                                        << ",workdir=" << work;
 
     int mountRes = mount("overlay", dst.c_str(), fstype.c_str(), flags, mountoptions.c_str());
 

--- a/common/mountcleanuphandler.cpp
+++ b/common/mountcleanuphandler.cpp
@@ -20,6 +20,7 @@
 
 #include "mountcleanuphandler.h"
 
+#include <sys/mount.h>
 
 MountCleanUpHandler::MountCleanUpHandler(const std::string &path)
 {

--- a/common/signalconnectionshandler.cpp
+++ b/common/signalconnectionshandler.cpp
@@ -17,27 +17,19 @@
  * For further information see LICENSE
  */
 
-#pragma once
+#include "signalconnectionshandler.h"
 
-#include "softwarecontainer-common.h"
-#include <jansson.h>
+namespace softwarecontainer {
 
-class FileGatewayParser
+void SignalConnectionsHandler::addConnection(sigc::connection &connection) {
+    m_connections.push_back(connection);
+}
+
+SignalConnectionsHandler::~SignalConnectionsHandler()
 {
-    LOG_DECLARE_CLASS_CONTEXT("FILP", "File gateway parser");
-public:
-    struct FileSetting {
-        std::string pathInHost;
-        std::string pathInContainer;
-        bool readOnly;
+    for (auto &connection : m_connections) {
+        connection.disconnect();
+    }
+}
 
-        bool operator==(const FileSetting &rhs) {
-            return pathInContainer == rhs.pathInContainer;
-        }
-    };
-
-    /*
-     * Check that the provided json configuration is syntactically correct
-     */
-    ReturnCode parseConfigElement(const json_t *element, FileSetting &setting);
-};
+}

--- a/common/signalconnectionshandler.h
+++ b/common/signalconnectionshandler.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include <sigc++/sigc++.h>
+#include <glibmm.h>
+
+#include <vector>
+#include <functional>
+
+#include <sys/types.h>
+
+namespace softwarecontainer {
+
+/**
+ * @brief The SignalConnectionsHandler class contains references to sigc++ connections and
+ * automatically disconnects them on destruction.
+ */
+class SignalConnectionsHandler
+{
+
+public:
+    /**
+     * Add a new connection
+     */
+    void addConnection(sigc::connection &connection);
+
+    ~SignalConnectionsHandler();
+
+private:
+    std::vector<sigc::connection> m_connections;
+
+};
+
+/**
+ * @brief addProcessListener Adds a glib child watch for a process.
+ * @warning This is not thread safe!
+ * @param connections Add the signal to this list of connections
+ * @param pid The pid to watch for.
+ * @param function A lambda/function pointer to run when the signal is sent for a process.
+ * @param context glib context to attach the SignalChildWatch to.
+ */
+inline void addProcessListener(
+    SignalConnectionsHandler &connections,
+    pid_t pid,
+    std::function<void(pid_t, int)> function,
+    Glib::RefPtr<Glib::MainContext> context)
+{
+    Glib::SignalChildWatch watch = context->signal_child_watch();
+    auto connection = watch.connect(function, pid);
+    connections.addConnection(connection);
+}
+
+} // end namespace

--- a/common/softwarecontainer-common.cpp
+++ b/common/softwarecontainer-common.cpp
@@ -18,19 +18,20 @@
  * For further information see LICENSE
  */
 
+#include "softwarecontainer-common.h"
 
-#include <string.h>
 #include <string>
 #include <iostream>
 #include <sstream>
-#include <fcntl.h>
 #include <fstream>
-#include "softwarecontainer-common.h"
 
+#include <unistd.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <fcntl.h>
 
 namespace softwarecontainer {
-
-LOG_DECLARE_DEFAULT_CONTEXT(defaultLogContext, "MAIN", "Main context");
+    LOG_DECLARE_DEFAULT_CONTEXT(defaultLogContext, "MAIN", "Main context");
 
 struct stat getStat(const std::string &path)
 {
@@ -168,18 +169,7 @@ bool parseInt(const char *arg, int *result)
     return true;
 }
 
-void SignalConnectionsHandler::addConnection(sigc::connection &connection) {
-    m_connections.push_back(connection);
-}
-
-SignalConnectionsHandler::~SignalConnectionsHandler()
-{
-    for (auto &connection : m_connections) {
-        connection.disconnect();
-    }
-}
-
-}
+} // end namespace
 
 
 

--- a/common/softwarecontainer-log.h
+++ b/common/softwarecontainer-log.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,13 +17,10 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
 
 #include "ivi-logging.h"
-#include <glibmm.h>
 
 namespace softwarecontainer {
     typedef logging::DefaultLogContext LogContext;
-    // LOG_IMPORT_DEFAULT_CONTEXT(defaultLogContext);
 }

--- a/libsoftwarecontainer/include/CMakeLists.txt
+++ b/libsoftwarecontainer/include/CMakeLists.txt
@@ -24,6 +24,7 @@ set(HEADERS
     containerabstractinterface.h
     workspace.h
     gateway.h
+    observableproperty.h
 )
 
 install(FILES ${HEADERS} DESTINATION include/softwarecontainer)

--- a/libsoftwarecontainer/include/observableproperty.h
+++ b/libsoftwarecontainer/include/observableproperty.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include <functional>
+#include <vector>
+
+template<typename Type>
+class ObservableProperty
+{
+public:
+    typedef std::function<void (const Type &)> Listener;
+
+    ObservableProperty(Type &value) :
+        m_value(value)
+    {
+    }
+
+    void addListener(Listener listener)
+    {
+        m_listeners.push_back(listener);
+    }
+
+    operator const Type &() {
+        return m_value;
+    }
+
+protected:
+    std::vector<Listener> m_listeners;
+
+private:
+    const Type &m_value;
+
+};
+
+template<typename Type>
+class ObservableWritableProperty :
+    public ObservableProperty<Type>
+{
+public:
+    ObservableWritableProperty(Type value) :
+        ObservableProperty<Type>(m_value), m_value(value)
+    {
+    }
+
+    ObservableWritableProperty() :
+        ObservableProperty<Type>(m_value)
+    {
+    }
+
+    void setValueNotify(Type value)
+    {
+        m_value = value;
+        for (auto &listener : ObservableProperty<Type>::m_listeners) {
+            listener(getValue());
+        }
+    }
+
+    const Type &getValue() const
+    {
+        return m_value;
+    }
+
+    ObservableWritableProperty &operator=(const Type &type)
+    {
+        m_value = type;
+        return *this;
+    }
+
+
+private:
+    Type m_value;
+
+};
+

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -21,17 +21,20 @@
 
 #pragma once
 
+#include "observableproperty.h"
+#include "workspace.h"
+#include "gateway.h"
+#include "container.h"
+#include "gatewayconfig.h"
+#include "signalconnectionshandler.h"
+
+#include <glibmm.h>
+
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include <glibmm.h>
-#include "workspace.h"
-#include "gateway.h"
-#include "container.h"
-#include "gatewayconfig.h"
 
 namespace softwarecontainer {
 

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -22,8 +22,11 @@
 #include <vector>
 #include <fstream>
 #include <unistd.h>
+
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/mount.h>
+
 #include <lxc/lxccontainer.h>
 #include <lxc/version.h>
 
@@ -174,7 +177,7 @@ ReturnCode Container::create()
     log_debug() << "Successfully loaded container config";
 
     // File system stuff
-    m_rootFSPath = StringBuilder() << s_LXCRoot << "/" << containerID << "/rootfs";
+    m_rootFSPath = logging::StringBuilder() << s_LXCRoot << "/" << containerID << "/rootfs";
 
     if (m_enableWriteBuffer) {
         const std::string rootFSPathLower = m_rootFSPath + "-lower";
@@ -400,7 +403,7 @@ ReturnCode Container::setUser(uid_t userID)
             return ReturnCode::FAILURE;
         }
 
-        StringBuilder s;
+        logging::StringBuilder s;
         for (auto &gid : groups) {
             s << " " << gid;
         }
@@ -754,7 +757,7 @@ ReturnCode Container::setEnvironmentVariable(const std::string &var, const std::
     m_gatewayEnvironmentVariables[var] = val;
 
     // We generate a file containing all variables for convenience when connecting to the container in command-line
-    StringBuilder s;
+    logging::StringBuilder s;
     for (auto &var : m_gatewayEnvironmentVariables) {
         s << "export " << var.first << "='" << var.second << "'\n";
     }

--- a/libsoftwarecontainer/src/gateway/cgroups/cgroupsparser.h
+++ b/libsoftwarecontainer/src/gateway/cgroups/cgroupsparser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "softwarecontainer-common.h"
+#include <jansson.h>
 
 class CGroupsParser
 {

--- a/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/softwarecontainerlib_unittest.cpp
@@ -80,8 +80,8 @@ TEST_F(SoftwareContainerApp, TestWaylandWhitelist) {
             return ERROR;
         }
         log_debug() << "Wayland dir : " << waylandDir;
-        std::string socketPath = StringBuilder() << waylandDir << "/"
-                                                 << WaylandGateway::SOCKET_FILE_NAME;
+        std::string socketPath = logging::StringBuilder() << waylandDir << "/"
+                                                          << WaylandGateway::SOCKET_FILE_NAME;
         log_debug() << "isSocket : " << socketPath << " " << isSocket(socketPath);
         if ( !isSocket(socketPath) ) {
             return ERROR;


### PR DESCRIPTION
* ObservableProperty and ObservableWritableProperty are split into
  separate file in libsoftwarecontainer.
* SignalConnectionsHandler is split out in separate file.
* softwarecontainer-common.h doesn't include everything anymore, which
  means that includes are placed where needed instead. This is only a
  partial cleanup, however.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>