### PR TITLE
Proper coverage support in CMake and Jenkinsfile.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ endif()
 
 if(ENABLE_COVERAGE)
     include(AddLCov)
-    add_coverage()
+    add_coverage("${CMAKE_BINARY_DIR}/run-tests.py")
 endif(ENABLE_COVERAGE)
 
 

--- a/README.md
+++ b/README.md
@@ -79,30 +79,31 @@ $ make
 $ sudo make install
 ```
 
-To build the project documentation set -DENABLE_ALL_DOC=ON when running cmake.
-You can also build the docs separately by pointing cmake to the doc
+To build the project documentation set ``-DENABLE_ALL_DOC=ON`` when running
+cmake. You can also build the docs separately by pointing cmake to the doc
 directory. Documentation is separated into doxygen docs (API level docs)
 and docs built with sphinx (user documentation and general docs on a higher
 level).
 
-To run the unit-tests build with -DENABLE_TEST=ON. To run code coverage tools
-build with -DENABLE_COVERAGE=ON.
+To run the unit-tests build with ``-DENABLE_TEST=ON``. To run code coverage tools
+build with ``-DENABLE_COVERAGE=ON``. Then run coverage with ``make lcov`` (needs
+to be run as root).
 
 To disable support for various gateways at compile time, set
-* -DENABLE_PULSEGATEWAY=OFF (for pulse)
-* -DENABLE_NETWORKGATEWAY=OFF (for network)
-* -DENABLE_DEVICENODEGATEWAY=OFF (for device node gateway)
-* -DENABLE_DBUSGATEWAY=OFF (for dbus)
-* -DENABLE_CGROUPSGATEWAY=OFF (for cgroups)
-* -DENABLE_WAYLANDGATEWAY=OFF (for wayland)
-* -DENABLE_FILEGATEWAY=OFF (for mounting files)
-* -DENABLE_ENVGATEWAY=OFF (for manipulating environment variables)
+* ``-DENABLE_PULSEGATEWAY=OFF`` (for pulse)
+* ``-DENABLE_NETWORKGATEWAY=OFF`` (for network)
+* ``-DENABLE_DEVICENODEGATEWAY=OFF`` (for device node gateway)
+* ``-DENABLE_DBUSGATEWAY=OFF`` (for dbus)
+* ``-DENABLE_CGROUPSGATEWAY=OFF`` (for cgroups)
+* ``-DENABLE_WAYLANDGATEWAY=OFF`` (for wayland)
+* ``-DENABLE_FILEGATEWAY=OFF`` (for mounting files)
+* ``-DENABLE_ENVGATEWAY=OFF`` (for manipulating environment variables)
 
-To build the examples, build with -DENABLE_EXAMPLES=ON (and see Examples
+To build the examples, build with ``-DENABLE_EXAMPLES=ON`` (and see Examples
 section).
 
 To prevent SoftwareContainer from creating a network bridge on startup (and
-instead only check that one is there), build with -DCREATE_BRIDGE=OFF.
+instead only check that one is there), build with ``-DCREATE_BRIDGE=OFF``.
 
 For a concrete example of building SoftwareContainer and setting up
 dependencies, see Vagrantfile in this repository. For an example on how to
@@ -118,9 +119,9 @@ build this code, please take a look at the Vagrantfile.
 ## Install without root
 In order to install SoftwareContainer without root there are two things that needs to be set.
 
-1. -DENABLE_SYSTEM_BUS needs to be set to OFF. The dbus xml that is needed for
+1. ``-DENABLE_SYSTEM_BUS`` needs to be set to OFF. The dbus xml that is needed for
    the system bus to be used can not be installed without root privileges.
-2. -DCMAKE_INSTALL_PREFIX needs to be set to a path the installing user has
+2. ``-DCMAKE_INSTALL_PREFIX`` needs to be set to a path the installing user has
    write access to.
 
 ## Building in Vagrant

--- a/cmake_modules/AddLCov.cmake
+++ b/cmake_modules/AddLCov.cmake
@@ -1,14 +1,15 @@
 # Macro for making it easy to use gcov/lcov
-macro(add_coverage)
+macro(add_coverage testCommand)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -O0")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
     find_program(LCOV lcov)
     find_program(GENHTML genhtml)
     if(LCOV AND GENHTML)
+
+        set(COV_DIR "coverage")
         add_custom_target(lcov)
         add_custom_command(
             TARGET lcov
-            COMMAND mkdir -p coverage
+            COMMAND mkdir -p ${COV_DIR}
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
 
@@ -16,42 +17,47 @@ macro(add_coverage)
         add_custom_command(
             TARGET lcov
             # Create baseline
-            COMMAND ${LCOV} --capture --initial --directory . --base-directory . --output-file coverage/baseline.info
+            COMMAND ${LCOV} --capture --initial --directory . --base-directory . --output-file ${COV_DIR}/baseline.info
             # Remove unwanted files from baseline data
-            COMMAND ${LCOV} --remove coverage/baseline.info \"/usr*\" --no-checksum --directory . --base-directory . --output-file coverage/baseline.info
-            COMMAND ${LCOV} --remove coverage/baseline.info \"gmock*\" --no-checksum --directory . --base-directory . --output-file coverage/baseline.info
-            COMMAND ${LCOV} --remove coverage/baseline.info \"gtest*\" --no-checksum --directory . --base-directory . --output-file coverage/baseline.info
-            COMMAND ${LCOV} --remove coverage/baseline.info \"unit-test*\" --no-checksum --directory . --base-directory . --output-file coverage/baseline.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/baseline.info \"/usr*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/baseline.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/baseline.info \"gmock*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/baseline.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/baseline.info \"gtest*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/baseline.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/baseline.info \"unit-test*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/baseline.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/baseline.info \"build*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/baseline.info
+            COMMENT "Getting lcov baseline data"
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
+
 
         # Run the actual tests and stuff
         add_custom_command(
             TARGET lcov
+
             # Run tests
-            COMMAND make test
+            COMMAND ${testCommand}
             # Capture coverage data after tests have run
-            COMMAND ${LCOV} --capture --directory . --base-directory . --output-file coverage/testrun.info
+            COMMAND ${LCOV} --capture --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
             # Remove unwanted files from captured data
-            COMMAND ${LCOV} --remove coverage/testrun.info \"/usr*\" --no-checksum --directory . --base-directory . --output-file coverage/testrun.info
-            COMMAND ${LCOV} --remove coverage/testrun.info \"gmock*\" --no-checksum --directory . --base-directory . --output-file coverage/testrun.info
-            COMMAND ${LCOV} --remove coverage/testrun.info \"gtest*\" --no-checksum --directory . --base-directory . --output-file coverage/testrun.info
-            COMMAND ${LCOV} --remove coverage/testrun.info \"unit-test*\" --no-checksum --directory . --base-directory . --output-file coverage/testrun.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/testrun.info \"/usr*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/testrun.info \"gmock*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/testrun.info \"gtest*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/testrun.info \"unit-test*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
+            COMMAND ${LCOV} --remove ${COV_DIR}/testrun.info \"build*\" --no-checksum --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
+            COMMENT "Running tests (${testCommand}) and lcov"
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
 
         add_custom_command(
             TARGET lcov
             # Combine baseline data and coverage data for accurate coverage stats
-            COMMAND ${LCOV} --add-tracefile coverage/baseline.info --add-tracefile coverage/testrun.info --output-file coverage/final.info
+            COMMAND ${LCOV} --add-tracefile ${COV_DIR}/baseline.info --add-tracefile ${COV_DIR}/testrun.info --output-file ${COV_DIR}/final.info
             # Generate HTML report
-            COMMAND genhtml --no-prefix coverage/final.info --output-directory coverage/
+            COMMAND genhtml --prefix ${CMAKE_SOURCE_DIR} ${COV_DIR}/final.info --output-directory ${COV_DIR}/
+            COMMENT "Combining baseline data with data from lcov run"
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
     else(LCOV AND GENHTML)
-        message(WARNING "Please install lcov and genhtml to enable the lcov target (apt-get install lcov)" )
+        message(WARNING "Please install lcov and genhtml to enable the lcov target")
     endif(LCOV AND GENHTML)
-    message("Code coverage enabled")
 endmacro(add_coverage)
-
 


### PR DESCRIPTION
The coverage macro was somewhat broken and has been fixed. The coverage
step was also added to the Jenkinsfile, and its results are published.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>