### PR TITLE
Added exceptions to Gateway base class

### DIFF
--- a/libsoftwarecontainer/src/gateway/gateway.cpp
+++ b/libsoftwarecontainer/src/gateway/gateway.cpp
@@ -24,6 +24,7 @@ bool Gateway::setConfig(const std::string &config)
 {
     if (m_state == GatewayState::ACTIVATED) {
         log_error() << "Can't configure a gateway that is already activated: " << id();
+        throw GatewayError("Gateway already activated");
     }
 
     json_error_t error;
@@ -62,18 +63,18 @@ bool Gateway::setConfig(const std::string &config)
 
 bool Gateway::activate() {
     if (m_state == GatewayState::ACTIVATED) {
-        log_warning() << "Activate was called on a gateway which was already activated: " << id();
-        return false;
+        log_error() << "Activate was called on a gateway which was already activated: " << id();
+        throw GatewayError("Gateway already activated");
     }
 
     if (m_state != GatewayState::CONFIGURED) {
-        log_warning() << "Activate was called on a gateway which is not in configured state: " << id();
-        return false;
+        log_error() << "Activate was called on a gateway which is not in configured state: " << id();
+        throw GatewayError("Gateway is not configured");
     }
 
     if (!hasContainer()) {
-        log_warning() << "Activate was called on a gateway which has no associated container: " << id();
-        return false;
+        log_error() << "Activate was called on a gateway which has no associated container: " << id();
+        throw GatewayError("Gateway does not have any container instance");
     }
 
     if (!activateGateway()) {
@@ -88,7 +89,7 @@ bool Gateway::activate() {
 bool Gateway::teardown() {
     if (m_state != GatewayState::ACTIVATED) {
         log_error() << "Teardown called on non-activated gateway: " << id();
-        return false;
+        throw GatewayError("Gateway not previosly activated");
     }
 
     if (!teardownGateway()) {

--- a/libsoftwarecontainer/unit-test/networkgateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/networkgateway_unittest.cpp
@@ -81,16 +81,15 @@ TEST_F(NetworkGatewayTest, Activate) {
 }
 
 /**
-
- * @brief Test NetworkGateway::activate is successful but that no network interface
- *  is brought up when the networking config is malformed.
+ * @brief Test that setConfig fails on malformed config and that activate throws
+ *        an exception when called and gateway is not configured.
  */
 TEST_F(NetworkGatewayTest, ActivateBadConfig) {
     givenContainerIsSet(gw);
     const std::string config = "[{\"internet-access\": true}]";
 
     ASSERT_FALSE(gw->setConfig(config));
-    ASSERT_FALSE(gw->activate());
+    ASSERT_THROW(gw->activate(), GatewayError);
 }
 
 /**


### PR DESCRIPTION
Making calls to gateways that are unreasonble because
of the gateway's state now results in exceptions. This
is a preparation for fixing the return value flow of
configuring and activating gateways e.g. when calling
SetCapabilities

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>