### PR TITLE
Jenkinsfile: destroy the VM last in the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,6 +125,6 @@ node {
 
     // Always try to shut down the machine
     // Shutdown the machine
-    sh "cd ${workspace} && vagrant halt || true"
+    sh "cd ${workspace} && vagrant destroy -f || true"
 }
 


### PR DESCRIPTION
We are only destroying the VM when we start a build, which means
that for pull requests, when the request is merged, a build is
not built more times, which leaves the VM hanging. If we destroy
it in the end of the run as well, we should not get this problem.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>