### PR TITLE
coverage: add support to give args to test run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ endif()
 
 if(ENABLE_COVERAGE)
     include(AddLCov)
-    add_coverage("${CMAKE_BINARY_DIR}/run-tests.py")
+    add_coverage("${CMAKE_BINARY_DIR}/run-tests.py" "-*SoftwareContainerApp.TestDBusGatewayOutputBuffer")
 endif(ENABLE_COVERAGE)
 
 

--- a/cmake_modules/AddLCov.cmake
+++ b/cmake_modules/AddLCov.cmake
@@ -1,5 +1,5 @@
 # Macro for making it easy to use gcov/lcov
-macro(add_coverage testCommand)
+macro(add_coverage testCommand testArgs)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -O0")
     find_program(LCOV lcov)
     find_program(GENHTML genhtml)
@@ -34,7 +34,7 @@ macro(add_coverage testCommand)
             TARGET lcov
 
             # Run tests
-            COMMAND ${testCommand}
+            COMMAND ${testCommand} ${testArgs}
             # Capture coverage data after tests have run
             COMMAND ${LCOV} --capture --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
             # Remove unwanted files from captured data


### PR DESCRIPTION
Currently we are having issues with one of the dbus tests taking long to
run, we want to be able to disable it temporarily.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>