### PR TITLE
 	Refactor gateway parser unittests 

### DIFF
--- a/libsoftwarecontainer/unit-test/cgroupsparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/cgroupsparser_unittest.cpp
@@ -18,30 +18,19 @@
  */
 
 #include "gateway/cgroups/cgroupsparser.h"
+#include "gateway_parser_common.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-class CGroupsParserTest : public ::testing::TestWithParam<std::string>
+class CGroupsParserTest : public GatewayParserCommon<std::string>
 {
 public:
     CGroupsParser parser;
     CGroupsParser::CGroupsPair result;
-    json_error_t err;
-    json_t *configJSON;
+
+    std::string config;
 
     void SetUp() override
     {
-        std::string config = GetParam();
-        configJSON = json_loads(config.c_str(), 0, &err);
-        ASSERT_TRUE(configJSON != NULL);
-    }
-
-    void TearDown() override
-    {
-        if (configJSON) {
-            json_decref(configJSON);
-        }
+        config = GetParam();
     }
 };
 
@@ -51,6 +40,7 @@ public:
  */
 typedef CGroupsParserTest CGroupsNegativeTest;
 TEST_P(CGroupsNegativeTest, FailsWhenConfigIsBad) {
+    json_t *configJSON = convertToJSON(config);
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseCGroupsGatewayConfiguration(configJSON, result));
     ASSERT_TRUE(result.first.empty());
     ASSERT_TRUE(result.second.empty());
@@ -62,6 +52,7 @@ TEST_P(CGroupsNegativeTest, FailsWhenConfigIsBad) {
  */
 typedef CGroupsParserTest CGroupsPositiveTest;
 TEST_P(CGroupsPositiveTest, SuccessWhenConfigIsGood) {
+    json_t *configJSON = convertToJSON(config);
     ASSERT_EQ(ReturnCode::SUCCESS, parser.parseCGroupsGatewayConfiguration(configJSON, result));
     ASSERT_FALSE(result.first.empty());
     ASSERT_FALSE(result.second.empty());

--- a/libsoftwarecontainer/unit-test/devicenodeparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodeparser_unittest.cpp
@@ -20,35 +20,13 @@
 
 
 #include "gateway/devicenode/devicenodeparser.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "gateway_parser_common.h"
 
-class DeviceNodeParserTest : public ::testing::TestWithParam<std::string>
+class DeviceNodeParserTest : public GatewayParserCommon<std::string>
 {
 public:
     DeviceNodeParser parser;
     DeviceNodeParser::Device result;
-
-    json_error_t err;
-    json_t *configJSON;
-
-    void SetUp() override
-    {
-    }
-
-    void convertToJSON(const std::string config)
-    {
-        configJSON = json_loads(config.c_str(), 0, &err);
-        ASSERT_TRUE(configJSON != NULL);
-    }
-
-    void TearDown()
-    {
-        if (configJSON) {
-            json_decref(configJSON);
-        }
-    }
-
 };
 
 /*
@@ -56,7 +34,7 @@ public:
  */
 TEST_F(DeviceNodeParserTest, TestConfigJustName) {
     const std::string config = "{ \"name\": \"/dev/random\" }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::SUCCESS, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -70,13 +48,13 @@ TEST_F(DeviceNodeParserTest, TestConfigJustName) {
  * Test that a full proper config works.
  */
 TEST_F(DeviceNodeParserTest, TestFullConfig) {
-    const std::string config = "{\
+    const std::string config1 = "{\
                                     \"name\":  \"/dev/new_device\",\
                                     \"major\": 1,\
                                     \"minor\": 0,\
                                     \"mode\":  644\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON1 = convertToJSON(config1);
     DeviceNodeParser::Device dev;
 
     const std::string config2 = "{\
@@ -86,9 +64,10 @@ TEST_F(DeviceNodeParserTest, TestFullConfig) {
                                     \"mode\":  764\
                                 }";
 
-    ASSERT_EQ(ReturnCode::SUCCESS, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
-    convertToJSON(config2);
-    ASSERT_EQ(ReturnCode::SUCCESS, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
+    ASSERT_EQ(ReturnCode::SUCCESS, parser.parseDeviceNodeGatewayConfiguration(configJSON1, dev));
+
+    json_t *configJSON2 = convertToJSON(config2);
+    ASSERT_EQ(ReturnCode::SUCCESS, parser.parseDeviceNodeGatewayConfiguration(configJSON2, dev));
     ASSERT_FALSE(dev.name.empty());
     ASSERT_NE(dev.major, -1);
     ASSERT_NE(dev.minor, -1);
@@ -104,7 +83,7 @@ TEST_F(DeviceNodeParserTest, TestConfigNoName) {
                                   \"minor\": 0,\
                                   \"mode\": 644\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -119,7 +98,7 @@ TEST_F(DeviceNodeParserTest, TestConfigNoMajor) {
                                   \"minor\": 0,\
                                   \"mode\": 644\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -134,7 +113,7 @@ TEST_F(DeviceNodeParserTest, TestConfigNoMinor) {
                                   \"major\": 0,\
                                   \"mode\": 644\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -149,7 +128,7 @@ TEST_F(DeviceNodeParserTest, TestConfigNoMode) {
                                   \"major\": 0,\
                                   \"minor\": 6\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -165,7 +144,7 @@ TEST_F(DeviceNodeParserTest, TestConfigBadMajor) {
                                   \"minor\": 6,\
                                   \"mode\": 644\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -181,7 +160,7 @@ TEST_F(DeviceNodeParserTest, TestConfigBadMainor) {
                                   \"minor\": \"B\",\
                                   \"mode\": 644\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
@@ -197,7 +176,7 @@ TEST_F(DeviceNodeParserTest, TestConfigBadMode) {
                                   \"minor\": 6,\
                                   \"mode\": \"C\"\
                                 }";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));

--- a/libsoftwarecontainer/unit-test/filegatewayparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/filegatewayparser_unittest.cpp
@@ -18,32 +18,14 @@
  */
 
 #include "gateway/files/filegatewayparser.h"
+#include "gateway_parser_common.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-class FileGatewayParserTest : public ::testing::Test
+class FileGatewayParserTest : public GatewayParserCommon<std::string>
 {
 public:
     FileGatewayParser parser;
     FileGatewayParser::FileSetting result;
     std::vector<FileGatewayParser::FileSetting> settings;
-
-    json_error_t err;
-    json_t *configJSON;
-
-    void convertToJSON(const std::string config)
-    {
-        configJSON = json_loads(config.c_str(), 0, &err);
-        ASSERT_TRUE(configJSON != NULL);
-    }
-
-    void TearDown() override
-    {
-        if (configJSON) {
-            json_decref(configJSON);
-        }
-    }
 
     const std::string FILE_PATH = "/tmp/filename.txt";
     const std::string CONTAINER_PATH = "/filename.txt";
@@ -58,7 +40,7 @@ TEST_F(FileGatewayParserTest, MinimalWorkingConf) {
             "  \"path-host\" : \"" + FILE_PATH + "\""
             ", \"path-container\" : \"" + CONTAINER_PATH + "\""
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::SUCCESS, parser.parseConfigElement(configJSON, result));
 }
@@ -72,7 +54,7 @@ TEST_F(FileGatewayParserTest, BadStrings) {
             "  \"path-host\": true"
             ", \"path-container\": 243"
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseConfigElement(configJSON, result));
     ASSERT_TRUE(result.pathInHost.empty());
@@ -89,7 +71,7 @@ TEST_F(FileGatewayParserTest, BadBools) {
             ", \"path-container\": \"" + CONTAINER_PATH + "\""
             ", \"read-only\": 0"
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseConfigElement(configJSON, result));
     ASSERT_FALSE(result.readOnly);
@@ -103,7 +85,7 @@ TEST_F(FileGatewayParserTest, NoPathInHost) {
         "{"
             "\"path-container\" : \"" + CONTAINER_PATH + "\""
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseConfigElement(configJSON, result));
 }
@@ -117,7 +99,7 @@ TEST_F(FileGatewayParserTest, EmptyPathInHost) {
             "  \"path-host\": \"\""
             ", \"path-container\" : \"" + CONTAINER_PATH + "\""
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseConfigElement(configJSON, result));
 }
@@ -130,7 +112,7 @@ TEST_F(FileGatewayParserTest, NoPathInContainer) {
         "{"
             "\"path-host\" : \"" + FILE_PATH + "\""
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseConfigElement(configJSON, result));
 }
@@ -144,7 +126,7 @@ TEST_F(FileGatewayParserTest, EmptyPathInContainer) {
             "  \"path-host\": \"" + FILE_PATH + "\""
             ", \"path-container\": \"\""
         "}";
-    convertToJSON(config);
+    json_t *configJSON = convertToJSON(config);
 
     ASSERT_EQ(ReturnCode::FAILURE, parser.parseConfigElement(configJSON, result));
 }

--- a/libsoftwarecontainer/unit-test/gateway_parser_common.h
+++ b/libsoftwarecontainer/unit-test/gateway_parser_common.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#pragma once
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "jansson.h"
+
+template <typename T>
+class GatewayParserCommon : public ::testing::TestWithParam<T>
+{
+public:
+    
+    json_error_t err;
+
+    /**
+     * @brief Converts a std::string to json_t* which is later cleaned up at teardown.
+     */
+    json_t *convertToJSON(const std::string &config)
+    {
+        json_t *jsonPtr = json_loads(config.c_str(), 0, &err);
+
+        teardownAtEndOfTest(jsonPtr);
+ 
+        return jsonPtr;
+    }
+
+    /**
+     * @brief Makes sure that the given json_t is propperly cleaned up at the end of a test
+     */
+    void teardownAtEndOfTest(json_t *jsonPtr)
+    {
+        if (jsonPtr != nullptr) {
+            jsonPtrs.push_back(jsonPtr);
+        }
+    }
+
+    /**
+     * @brief Cleanup the json
+     */
+    void TearDown() override
+    {
+        for(json_t *jsonPtr : jsonPtrs) {
+            if (jsonPtr != nullptr) { 
+                json_decref(jsonPtr);
+            }
+        }
+        jsonPtrs.clear();
+    }
+
+
+private:
+    std::vector<json_t *> jsonPtrs;
+
+};

--- a/libsoftwarecontainer/unit-test/networkgatewayparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/networkgatewayparser_unittest.cpp
@@ -22,12 +22,11 @@
 #include "softwarecontainer-common.h"
 #include "gateway/network/networkgatewayparser.h"
 #include "gateway/network/iptableentry.h"
+#include "gateway_parser_common.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include <jansson.h>
 
-class NetworkGatewayParserTest : public ::testing::Test
+class NetworkGatewayParserTest : public GatewayParserCommon<std::string>
 {
 protected:
     NetworkGatewayParser networkParser;
@@ -52,10 +51,8 @@ TEST_F(NetworkGatewayParserTest, InputSingularPort) {
 
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
     ASSERT_EQ(IPTableEntry::Target::DROP, e.m_defaultTarget);
     ASSERT_EQ("INPUT", e.m_type);
@@ -65,8 +62,6 @@ TEST_F(NetworkGatewayParserTest, InputSingularPort) {
     ASSERT_EQ(0, e.m_rules[0].ports.multiport);
     ASSERT_EQ("80", e.m_rules[0].ports.ports);
     ASSERT_EQ(IPTableEntry::Target::ACCEPT, e.m_rules[0].target);
-
-    json_decref(root);
 }
 
 /*
@@ -87,10 +82,8 @@ TEST_F(NetworkGatewayParserTest, InputMultiplePort) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
     ASSERT_EQ(IPTableEntry::Target::DROP, e.m_defaultTarget);
     ASSERT_EQ("INPUT", e.m_type);
@@ -100,8 +93,6 @@ TEST_F(NetworkGatewayParserTest, InputMultiplePort) {
     ASSERT_EQ(1, e.m_rules[0].ports.multiport);
     ASSERT_EQ("80,8080", e.m_rules[0].ports.ports);
     ASSERT_EQ(IPTableEntry::Target::ACCEPT, e.m_rules[0].target);
-
-    json_decref(root);
 }
 
 /*
@@ -120,10 +111,8 @@ TEST_F(NetworkGatewayParserTest, PortTypo) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
     ASSERT_EQ(IPTableEntry::Target::DROP, e.m_defaultTarget);
     ASSERT_EQ("OUTPUT", e.m_type);
@@ -132,8 +121,6 @@ TEST_F(NetworkGatewayParserTest, PortTypo) {
     ASSERT_NE(1, e.m_rules[0].ports.any);
     ASSERT_EQ("tcp", e.m_rules[0].protocols[0]);
     ASSERT_EQ(IPTableEntry::Target::ACCEPT, e.m_rules[0].target);
-
-    json_decref(root);
 }
 
 
@@ -156,10 +143,8 @@ TEST_F(NetworkGatewayParserTest, OutputMultiplePort) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
     ASSERT_EQ(IPTableEntry::Target::DROP, e.m_defaultTarget);
     ASSERT_EQ("OUTPUT", e.m_type);
@@ -170,8 +155,6 @@ TEST_F(NetworkGatewayParserTest, OutputMultiplePort) {
     ASSERT_EQ("80:8080", e.m_rules[0].ports.ports);
     ASSERT_EQ("tcp", e.m_rules[0].protocols[0]);
     ASSERT_EQ(IPTableEntry::Target::ACCEPT, e.m_rules[0].target);
-
-    json_decref(root);
 }
 
 
@@ -190,14 +173,9 @@ TEST_F(NetworkGatewayParserTest, OutputNoHost) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_NE(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
-
-
-    json_decref(root);
 }
 
 
@@ -214,16 +192,12 @@ TEST_F(NetworkGatewayParserTest, OutputNoPort) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
 
     ASSERT_EQ("127.0.0.1/16", e.m_rules[0].host);
     ASSERT_EQ(0, e.m_rules[0].ports.any);
-
-    json_decref(root);
 }
 
 /**
@@ -237,13 +211,9 @@ TEST_F(NetworkGatewayParserTest, SetConfigNoRules) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_NE(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
-
-    json_decref(root);
 }
 
 /**
@@ -258,13 +228,9 @@ TEST_F(NetworkGatewayParserTest, SetConfigEmptyRules) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
-
-    json_decref(root);
 }
 
 /**
@@ -279,13 +245,9 @@ TEST_F(NetworkGatewayParserTest, TestSetConfigRulesIsInteger) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_NE(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
-
-    json_decref(root);
 }
 
 
@@ -303,10 +265,8 @@ TEST_F(NetworkGatewayParserTest, MultipleProtocols) {
     "}";
 
     IPTableEntry e;
-    json_error_t error;
-    json_t *root = json_loads(config.c_str(), 0, &error);
+    json_t *root = convertToJSON(config);
 
-    ASSERT_NE(nullptr, root);
     ASSERT_EQ(ReturnCode::SUCCESS, networkParser.parseNetworkGatewayConfiguration(root, e));
     ASSERT_EQ(IPTableEntry::Target::DROP, e.m_defaultTarget);
     ASSERT_EQ("INPUT", e.m_type);
@@ -316,6 +276,4 @@ TEST_F(NetworkGatewayParserTest, MultipleProtocols) {
     ASSERT_EQ("tcp", e.m_rules[0].protocols[0]);
     ASSERT_EQ("udp", e.m_rules[0].protocols[1]);
     ASSERT_EQ(IPTableEntry::Target::ACCEPT, e.m_rules[0].target);
-
-    json_decref(root);
 }


### PR DESCRIPTION
Add a class, GatewayParserCommon, for handling memory allocation of jansson.

Refactor existing parser tests.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>