### PR TITLE
Fixes spawn regression by only using one core

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,18 +36,9 @@ node {
                 println "Will set VAGRANT_RAM to ${gigsram}"
             }
 
-            // And calculate number of CPUS available
-            String numcpus = sh (
-                script: 'nproc',
-                returnStdout: true
-            )
-
-            println "Will set VAGRANT_CPUS to ${numcpus}"
-
             // Start the machine (destroy it if present) and provision it
             sh "cd ${workspace} && vagrant destroy -f || true"
             withEnv(["VAGRANT_RAM=${gigsram}",
-                     "VAGRANT_CPUS=${numcpus}",
                      "APT_CACHE_SERVER=10.8.36.16"]) {
                 sh "cd ${workspace} && vagrant up"
             }
@@ -74,8 +65,7 @@ node {
         }
 
         stage('UnitTest') {
-            String testArg = "-*OutputBuffer"
-            runInVagrant(workspace, "cd softwarecontainer/build && sudo ./run-tests.py ${testArg}")
+            runInVagrant(workspace, "cd softwarecontainer/build && sudo ./run-tests.py")
         }
 
         stage('ServiceTest') {

--- a/servicetest/dbus/test_dbus.py
+++ b/servicetest/dbus/test_dbus.py
@@ -98,7 +98,6 @@ class TestDBus(object):
             finally:
                 ca.terminate()
 
-    @pytest.mark.skip(reason="See reported issue about this")
     def test_query_out(self):
         """ Launch client in container and test if it communicates out """
         for x in range(0, 10):


### PR DESCRIPTION
For some reason, when running with multiple cores and virtualbox,
performance degrades when stress testing by spawning many processes. An
article (http://www.mihaimatei.com/virtualbox-performance-issues-multiple-cpu-cores/)
suggests this is because processing with multicore in VBox requires the
physical cores it uses to be free (and locking more cpus take more
time).

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>