### PR TITLE
Jenkinsfile: avoid unreachable paths with coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ endif()
 
 if(ENABLE_COVERAGE)
     include(AddLCov)
-    add_coverage("${CMAKE_BINARY_DIR}/run-tests.py" "-*SoftwareContainerApp.TestDBusGatewayOutputBuffer")
+    add_coverage("${CMAKE_BINARY_DIR}/run-tests.py")
 endif(ENABLE_COVERAGE)
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,8 @@ node {
         }
 
         stage('UnitTest') {
-            runInVagrant(workspace, "cd softwarecontainer/build && sudo ./run-tests.py")
+            // We run it in this way to avoid getting (unreachable) paths
+            runInVagrant(workspace, "cd softwarecontainer && sudo ./build/run-tests.py")
         }
 
         stage('ServiceTest') {
@@ -73,7 +74,8 @@ node {
         }
 
         stage('Coverage') {
-            runInVagrant(workspace, "cd softwarecontainer/build && sudo make lcov")
+            // We run it in this way to avoid getting (unreachable) paths
+            runInVagrant(workspace, "cd softwarecontainer && sudo make -C build lcov")
         }
 
         stage('Examples') {

--- a/cmake_modules/AddLCov.cmake
+++ b/cmake_modules/AddLCov.cmake
@@ -1,5 +1,5 @@
 # Macro for making it easy to use gcov/lcov
-macro(add_coverage testCommand testArgs)
+macro(add_coverage testCommand)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -O0")
     find_program(LCOV lcov)
     find_program(GENHTML genhtml)
@@ -35,7 +35,7 @@ macro(add_coverage testCommand testArgs)
             TARGET lcov
 
             # Run tests
-            COMMAND ${testCommand} ${testArgs}
+            COMMAND ${testCommand}
             # Capture coverage data after tests have run
             COMMAND ${LCOV} --capture --directory . --base-directory . --output-file ${COV_DIR}/testrun.info
             # Remove unwanted files from captured data

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -92,6 +92,7 @@ if len(sys.argv) > 1:
 testSuites = { }
 def runTestSuite(binary, name):
     outputFile = "{}_unittest_result.xml".format(name)
+    os.system("rm " + outputFile);
     command = "{} {} --gtest_output=xml:{}".format(binary, gtestFilter, outputFile)
     exitCode = os.system(command)
     testSuites[name] = exitCode


### PR DESCRIPTION
We sometimes end up having (unreachable) paths when running in Jenkins, resulting in some unit test results being reported twice.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>