### PR TITLE
pulsegateway: removes pulse includes, not used

### DIFF
--- a/libsoftwarecontainer/src/gateway/pulsegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.cpp
@@ -18,8 +18,6 @@
  * For further information see LICENSE
  */
 
-
-#include <stdio.h>
 #include "pulsegateway.h"
 
 PulseGateway::PulseGateway() :

--- a/libsoftwarecontainer/src/gateway/pulsegateway.h
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <pulse/pulseaudio.h>
 #include "gateway.h"
 
 /**


### PR DESCRIPTION
The pulse gateway does not interact directly with pulseaudio. Rather, it
exposes the socket on which the server runs to the container. That means
there is no need to have pulse specific headers included.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>