### PR TITLE
Fixes for missing dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ pkg_check_modules(DBusCpp       REQUIRED dbus-c++-glib-1>=0.9.0)
 pkg_check_modules(Glibmm        REQUIRED glibmm-2.4>=2.42.0)
 pkg_check_modules(LXC           REQUIRED lxc>=2.0.0)
 pkg_check_modules(Jansson       REQUIRED jansson>=2.6)
+pkg_check_modules(sigc          REQUIRED sigc++-2.0)
 
 # These are needed by all sub-projects
 add_definitions(${IVILogging_CFLAGS_OTHER})

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -44,7 +44,8 @@ add_library(softwarecontainercommon SHARED
 )
 
 target_link_libraries(softwarecontainercommon
-   ${Jansson_LIBRARIES})
+    ${Jansson_LIBRARIES}
+    ${sigc_LIBRARIES})
 
 install(FILES ${HEADERS} DESTINATION include/softwarecontainer)
 install(TARGETS softwarecontainercommon DESTINATION lib)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -43,6 +43,9 @@ add_library(softwarecontainercommon SHARED
     signalconnectionshandler.cpp
 )
 
+target_link_libraries(softwarecontainercommon
+   ${Jansson_LIBRARIES})
+
 install(FILES ${HEADERS} DESTINATION include/softwarecontainer)
 install(TARGETS softwarecontainercommon DESTINATION lib)
 


### PR DESCRIPTION
During the native build, a compiling and linking errors occurs due to missing dependencies in CMake files. With those small changes I'm able to do a native build (checked on Ubuntu 16.04).