### PR TITLE
Added support for mandatory configs

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOFTWARECONTAINERAGENT_CORE_CLASSES
     ${SOFTWARECONTAINERAGENT_DIR}/src/config/config.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/config/fileconfigloader.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/config/configdefaults.cpp
+    ${SOFTWARECONTAINERAGENT_DIR}/src/config/mandatoryconfigs.cpp
 )
 
 add_executable(softwarecontainer-agent

--- a/agent/softwarecontainer-config.in
+++ b/agent/softwarecontainer-config.in
@@ -5,9 +5,13 @@
 # Optional configs are commented out by default, but are set to the default
 # values that will be used by SoftwareContainer if nothing else is specified.
 # Any configs that are not commented out by default are mandatory and must
-# be present and set to a valid value.
+# be present and set to a valid value by the user.
 #
-# The group 'SoftwareContainer' must be present.
+# Config keys are unique to their respective group. Consequently, the same
+# config key can appear in different groups. It is an error to move a config
+# from its group.
+#
+# Config groups that are not commented out are mandatory.
 #
 
 [SoftwareContainer]

--- a/agent/src/config/config.h
+++ b/agent/src/config/config.h
@@ -27,20 +27,130 @@
 #include "softwarecontainer-common.h"
 #include "configloaderabstractinterface.h"
 #include "configdefaults.h"
+#include "mandatoryconfigs.h"
 
 
 namespace softwarecontainer {
 
 class ConfigError : public std::exception
 {
+public:
+    ConfigError():
+        m_message("SoftwareContainer configuration error")
+    {
+    }
+
+    ConfigError(const std::string &message):
+        m_message(message)
+    {
+    }
+
     virtual const char *what() const throw()
     {
-        return "SoftwareContainer configuration error.";
+        return m_message.c_str();
+    }
+
+protected:
+    std::string m_message;
+};
+
+
+class ConfigDependencyError : public ConfigError
+{
+public:
+    ConfigDependencyError():
+        ConfigError("Configuration error - missing config dependency")
+    {
+    }
+
+    ConfigDependencyError(const std::string &message):
+        ConfigError(message)
+    {
+    }
+
+    virtual const char *what() const throw()
+    {
+        return ConfigError::m_message.c_str();
     }
 };
-}
 
 
+class ConfigMandatoryError : public ConfigError
+{
+public:
+    ConfigMandatoryError():
+        ConfigError("Configuration error - missing mandatory config")
+    {
+    }
+
+    ConfigMandatoryError(const std::string &message):
+        ConfigError(message)
+    {
+    }
+
+    // TODO: Can these be removed since we initialize the parent with a message anyway?
+    virtual const char *what() const throw()
+    {
+        return ConfigError::m_message.c_str();
+    }
+};
+
+
+/**
+ * @brief Represents the type of a config value
+ *
+ * This is used to specify the type of the a value when mandatory configs are
+ * defined. This information is later used to know how a key should be used to
+ * retrive a value, e.g. what type specific methods can be used.
+ */
+enum class ConfigType
+{
+    String,
+    Integer,
+    Boolean
+};
+
+
+/**
+ * @brief Represents the SoftwareContainer main config
+ *
+ * A 'config' is a key-value pair, a 'config source' is somewhere that these key-value pairs
+ * are defined.
+ *
+ * There are three different config sources:
+ *   * Command line options
+ *   * Main config file
+ *   * Defaults
+ *
+ * Some configs are optional and some are mandatory. A config can become mandatory if
+ * some other specified config depends on it. E.g. if an optional config in the main config
+ * file is uncommented and thus used, it might mean that other configs are mandatory
+ * as a consequence. A mandatory config must always be present in the command line options
+ * or in the main config file.
+ *
+ * In the main config file, there are also 'confgig groups' which some might be mandatory and
+ * others not. Groups does not exist in the other config sources.
+ *
+ * NOTE: It is an error if a mandatory config is not found in any config source when Config
+ *       is initialized.
+ *
+ * NOTE: It is en error if a dependency to a config is not found in any config source when
+ *       Config is initialized.
+ *
+ * NOTE: It is an error if a mandatory config group is not found in the main config file when
+ *       Config is initialized.
+ *
+ * Config sources have an order of priority:
+ *   1 - Command line options
+ *   2 - Main config file
+ *   3 - Defaults
+ *
+ * The config sources as considered in the above order, i.e. first command line options etc.
+ * As soon as a config is found in a source, the value is returned and less prioritized sources
+ * are ignored.
+ *
+ * NOTE: It is an error if a config is requested and not found in any source.
+ */
 class Config
 {
 
@@ -72,13 +182,28 @@ public:
      * @param intOptions A string:int map with config keys and corresponding values
      * @param boolOptions A string:bool map with config keys and corresponding values
      *
-     * @throws softwarecontainer::ConfigError On error
+     * @throws ConfigError On error
      */
     Config(std::unique_ptr<ConfigLoaderAbstractInterface> loader,
            std::unique_ptr<ConfigDefaults> defaults,
            const std::map<std::string, std::string> &stringOptions = std::map<std::string, std::string>(),
            const std::map<std::string, int> &intOptions = std::map<std::string, int>(),
            const std::map<std::string, bool> &boolOptions = std::map<std::string, bool>());
+
+    /**
+     * TODO: Find a way to reuse parts of above comment
+     *
+     * @param mandatory A reference to a MandatoryConfigs object that specifies what configs
+     *                  will be considered mandatory.
+     * @param dependencies A list of dependee keys mapping to lists of dependency keys
+     */
+    Config(std::unique_ptr<ConfigLoaderAbstractInterface> loader,
+        std::unique_ptr<ConfigDefaults> defaults,
+        MandatoryConfigs &mandatory,
+        std::vector<std::pair<std::string, std::vector<std::string>>> &dependencies,
+        const std::map<std::string, std::string> &stringOptions = std::map<std::string, std::string>(),
+        const std::map<std::string, int> &intOptions = std::map<std::string, int>(),
+        const std::map<std::string, bool> &boolOptions = std::map<std::string, bool>());
 
     /**
      * @brief getStringValue Get a config value of type string
@@ -143,9 +268,19 @@ private:
     T getGlibValue(const std::string &group,
                    const std::string &key) const;
 
+    /**
+     * @brief Load main config file source into member m_config
+     *
+     * @throws ConfigError On error
+     */
+    void loadConfig();
+
+    std::unique_ptr<ConfigLoaderAbstractInterface> m_loader;
     std::unique_ptr<Glib::KeyFile> m_config;
     std::unique_ptr<ConfigDefaults> m_defaults;
     std::map<std::string, std::string> m_stringOptions;
     std::map<std::string, int> m_intOptions;
     std::map<std::string, bool> m_boolOptions;
 };
+
+} // namespace softwarecontainer

--- a/agent/src/config/mandatoryconfigs.cpp
+++ b/agent/src/config/mandatoryconfigs.cpp
@@ -1,0 +1,46 @@
+
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include "mandatoryconfigs.h"
+
+
+MandatoryConfigs::MandatoryConfigs():
+    m_configs(std::vector<std::tuple<std::string, std::string, ConfigType>>()),
+    m_groups(std::vector<std::string>())
+{
+}
+
+void MandatoryConfigs::addConfig(const std::string &group, const std::string &key, ConfigType type)
+{
+    log_debug() << "Adding mandatory config \"" << key << "\" with group \"" << group << "\"";
+    m_groups.push_back(group);
+    std::tuple<std::string, std::string, ConfigType> config = std::make_tuple(group, key, type);
+    m_configs.push_back(config);
+}
+
+std::vector<std::tuple<std::string, std::string, ConfigType>> MandatoryConfigs::configs()
+{
+    return m_configs;
+}
+
+std::vector<std::string> MandatoryConfigs::groups()
+{
+    return m_groups;
+}

--- a/agent/src/config/mandatoryconfigs.h
+++ b/agent/src/config/mandatoryconfigs.h
@@ -1,0 +1,74 @@
+
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#pragma once
+
+#include "softwarecontainer-common.h"
+
+
+namespace softwarecontainer {
+
+// Forward declared to avoid circular include with config.h
+enum class ConfigType;
+
+
+class MandatoryConfigs
+{
+
+LOG_DECLARE_CLASS_CONTEXT("CFGM", "SoftwareContainer general config mandatory values");
+
+public:
+    MandatoryConfigs();
+
+    ~MandatoryConfigs() {}
+
+    /**
+     * @brief Adds a mandatory config key with associated group
+     *
+     * Both the group and key will become mandatory.
+     *
+     * @param group The name of the group the key is in
+     * @param key The name of the config key
+     * @param type A ConfigType specifying the type of the config value
+     */
+    void addConfig(const std::string &group, const std::string &key, ConfigType type);
+
+    /**
+     * @brief Get all mandatory configs as group and key
+     *
+     * @returns A list of group-key-type tuples
+     *
+     * TODO: Do we really need to have the group present here again?
+     */
+    std::vector<std::tuple<std::string, std::string, ConfigType>> configs();
+
+    /**
+     * @brief Get all mandatory config groups
+     *
+     * @returns A list of group names
+     */
+    std::vector<std::string> groups();
+
+private:
+    std::vector<std::tuple<std::string, std::string, ConfigType>> m_configs;
+    std::vector<std::string> m_groups;
+};
+
+} // namespace softwarecontainer

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -36,7 +36,7 @@ SoftwareContainerAgent::SoftwareContainerAgent(
         //      but doesn't seem to work anyway, see bug
         m_shutdownContainers = !config.getBooleanValue(Config::SC_GROUP,
                                                        Config::KEEP_CONTAINERS_ALIVE_KEY);
-    } catch (softwarecontainer::ConfigError &error) {
+    } catch (ConfigError &error) {
         throw ReturnCode::FAILURE;
     }
 
@@ -48,7 +48,7 @@ SoftwareContainerAgent::SoftwareContainerAgent(
         shutdownTimeout = config.getIntegerValue(Config::SC_GROUP, Config::SHUTDOWN_TIMEOUT_KEY);
         containerRootDir = config.getStringValue(Config::SC_GROUP, Config::SHARED_MOUNTS_DIR_KEY);
         lxcConfigPath = config.getStringValue(Config::SC_GROUP, Config::LXC_CONFIG_PATH_KEY);
-    } catch (softwarecontainer::ConfigError &error) {
+    } catch (ConfigError &error) {
         throw ReturnCode::FAILURE;
     }
 
@@ -77,7 +77,7 @@ SoftwareContainerAgent::SoftwareContainerAgent(
                                                    Config::SERVICE_MANIFEST_DIR_KEY);
         defaultServiceManifestDir = config.getStringValue(Config::SC_GROUP,
                                                           Config::DEFAULT_SERVICE_MANIFEST_DIR_KEY);
-    } catch (softwarecontainer::ConfigError &error) {
+    } catch (ConfigError &error) {
         throw ReturnCode::FAILURE;
     }
 


### PR DESCRIPTION
It's now possible to specify that some configs
are mandatory. This is currently not used by the agent
but will be needed when we move to having certain configs
made mandatory due to how SC is configured and built, e.g.
for networking.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>