### PR TITLE
Use Giomm dbus instead of dbus-c++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ endif(EXTRA_PKG_CONFIG_PATH)
 find_package(PkgConfig          REQUIRED)
 
 pkg_check_modules(IVILogging    REQUIRED ivi-logging>=1.3.0)
-pkg_check_modules(DBusCpp       REQUIRED dbus-c++-glib-1>=0.9.0)
 pkg_check_modules(Glibmm        REQUIRED glibmm-2.4>=2.42.0)
+pkg_check_modules(Giomm         REQUIRED giomm-2.4>=2.42.0)
 pkg_check_modules(LXC           REQUIRED lxc>=2.0.0)
 pkg_check_modules(Jansson       REQUIRED jansson>=2.6)
 
@@ -62,20 +62,20 @@ pkg_check_modules(Jansson       REQUIRED jansson>=2.6)
 add_definitions(${IVILogging_CFLAGS_OTHER})
 add_definitions(${Jansson_CFLAGS_OTHER})
 
-add_definitions(${DBusCpp_CFLAGS_OTHER})
 add_definitions(${Glibmm_CFLAGS_OTHER})
+add_definitions(${Giomm_CFLAGS_OTHER})
 add_definitions(${LXC_CFLAGS_OTHER})
 add_definitions(-DINSTALL_BINDIR="${CMAKE_INSTALL_FULL_BINDIR}")
 
 include_directories(${IVILogging_INCLUDE_DIRS})
-include_directories(${DBusCpp_INCLUDE_DIRS})
 include_directories(${Glibmm_INCLUDE_DIRS})
+include_directories(${Giomm_INCLUDE_DIRS})
 include_directories(${LXC_INCLUDE_DIRS})
 include_directories(${Jansson_INCLUDE_DIRS})
 
 link_directories(${IVILogging_LIBRARY_DIRS})
-link_directories(${DBusCpp_LIBRARY_DIRS})
 link_directories(${Glibmm_LIBRARY_DIRS})
+link_directories(${Giomm_LIBRARY_DIRS})
 link_directories(${LXC_LIBRARY_DIRS})
 link_directories(${Jansson_LIBRARY_DIRS})
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
         String buildParams = "-DENABLE_TEST=ON -DENABLE_COVERAGE=ON "
         buildParams       += "-DENABLE_USER_DOC=ON -DENABLE_API_DOC=ON "
         buildParams       += "-DENABLE_SYSTEMD=ON -DENABLE_PROFILING=ON "
-        buildParams       += "-DENABLE_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=/usr"
+        buildParams       += "-DCMAKE_INSTALL_PREFIX=/usr"
 
         // Stages are subtasks that will be shown as subsections of the finiished build in Jenkins.
         stage('Download') {
@@ -46,7 +46,7 @@ node {
 
         stage('Build') {
             runInVagrant(workspace, "sh ./softwarecontainer/cookbook/build/cmake-builder.sh \
-                                     softwarecontainer \"${buildParams}\"")
+                                     softwarecontainer \"${buildParams}\" -DENABLE_EXAMPLES=ON")
         }
 
         // TODO: Haven't figured out how to make the parallel jobs run on the same slave/agent

--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -16,8 +16,6 @@
 # For further information see LICENSE
 
 include(GNUInstallDirs)
-include(GenerateDBusCpp)
-generate_dbuscpp_hfile(${CMAKE_CURRENT_SOURCE_DIR}/softwarecontainer-agent.xml "SoftwareContainerAgent")
 
 install(DIRECTORY DESTINATION ${SERVICE_MANIFEST_DIR})
 install(DIRECTORY DESTINATION ${DEFAULT_SERVICE_MANIFEST_DIR})
@@ -29,6 +27,8 @@ include_directories(src)
 #
 add_executable(softwarecontainer-agent
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/softwarecontaineragent_dbus_common.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/softwarecontaineragent_dbus_stub.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/softwarecontaineragent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/softwarecontaineragentadaptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/capability/baseconfigstore.cpp
@@ -42,7 +42,7 @@ add_executable(softwarecontainer-agent
 )
 
 target_link_libraries(softwarecontainer-agent
-    ${DBusCpp_LIBRARIES}
+    ${Giomm_LIBRARIES}
     ${IVILogging_LIBRARIES}
     softwarecontainer
 )

--- a/agent/component-test/CMakeLists.txt
+++ b/agent/component-test/CMakeLists.txt
@@ -18,7 +18,7 @@
 include(AddGTestTest)
 
 set(AGENT_TEST_LIBRARY_DEPENDENCIES
-    ${DBusCpp_LIBRARIES}
+    ${Giomm_LIBRARIES}
     ${GLibmm_LIBRARIES}
     ${IVILogging_LIBRARIES}
     softwarecontainer
@@ -27,6 +27,8 @@ set(AGENT_TEST_LIBRARY_DEPENDENCIES
 set(SOFTWARECONTAINERAGENT_TEST_FILES
     main.cpp
     softwarecontaineragent_unittest.cpp
+    ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragent_dbus_common.cpp
+    ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragent_dbus_stub.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragent.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragentadaptor.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/capability/baseconfigstore.cpp

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -26,18 +26,8 @@
 #include <glib-unix.h>
 #include <glibmm.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-    #include <dbus-c++/dbus.h>
-    #include <dbus-c++/glib-integration.h>
-#pragma GCC diagnostic pop
-
 #include <ivi-profiling.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-    #include "SoftwareContainerAgent_dbuscpp_adaptor.h"
-#pragma GCC diagnostic pop
 
 #include "softwarecontainer.h"
 #include "softwarecontainer-common.h"

--- a/agent/src/softwarecontaineragent_dbus_common.h
+++ b/agent/src/softwarecontaineragent_dbus_common.h
@@ -1,0 +1,89 @@
+
+#pragma once
+#include <iostream>
+#include "glibmm.h"
+#include "giomm.h"
+
+
+class SoftwareContainerAgentCommon {
+    public:
+        template<typename T>
+        static void unwrapList(std::vector<T> &list, const Glib::VariantContainerBase &wrapped) {
+            for (uint i = 0; i < wrapped.get_n_children (); i++) {
+                Glib::Variant<T> item;
+                wrapped.get_child(item, i);
+                list.push_back(item.get());
+            }
+        }
+
+        static std::vector<Glib::ustring> stdStringVecToGlibStringVec(const std::vector<std::string> &strv) {
+            std::vector<Glib::ustring> newStrv;
+            for (uint i = 0; i < strv.size(); i++) {
+                newStrv.push_back(strv[i]);
+            }
+
+            return newStrv;
+        }
+
+        static std::vector<std::string> glibStringVecToStdStringVec(const std::vector<Glib::ustring> &strv) {
+            std::vector<std::string> newStrv;
+            for (uint i = 0; i < strv.size(); i++) {
+                newStrv.push_back(strv[i]);
+            }
+
+            return newStrv;
+        }
+
+        static std::map<std::string, std::string> glibStringMapToStdStringMap(const std::map<Glib::ustring, Glib::ustring> &strm) {
+            std::map<std::string, std::string> newStrm;
+            for (std::pair<Glib::ustring, Glib::ustring> pair : strm) {
+                std::pair<std::string, std::string> newPair(pair.first, pair.second);
+                newStrm.insert(newPair);
+            }
+
+            return newStrm;
+        }
+
+        template <typename T0, typename T1>
+        static std::vector<T1> mapVector(const std::vector<T0> &vector0, std::function<T1(T0)> mapFunction) {
+            std::vector<T1> vector1;
+            for (T0 &e : vector0) {
+                vector1.push_back(mapFunction(e));
+            }
+
+            return vector1;
+        }
+};
+class SoftwareContainerAgentMessageHelper {
+public:
+    SoftwareContainerAgentMessageHelper (const Glib::RefPtr<Gio::DBus::MethodInvocation> msg) :
+        m_message(msg) {}
+
+    const Glib::RefPtr<Gio::DBus::MethodInvocation> getMessage() {
+        return m_message;
+    }
+
+template <typename T0>
+void ret(T0 p0)
+{
+    std::vector<Glib::VariantBase> vlist;
+    vlist.push_back(Glib::Variant<T0>::create(p0));
+
+    m_message->return_value(Glib::Variant<Glib::VariantBase>::create_tuple(vlist));
+}
+
+template <typename T0,typename T1>
+void ret(T0 p0, T1 p1)
+{
+    std::vector<Glib::VariantBase> vlist;
+    vlist.push_back(Glib::Variant<T0>::create(p0));
+    vlist.push_back(Glib::Variant<T1>::create(p1));
+
+    m_message->return_value(Glib::Variant<Glib::VariantBase>::create_tuple(vlist));
+}
+
+
+
+private:
+    Glib::RefPtr<Gio::DBus::MethodInvocation> m_message;
+};

--- a/agent/src/softwarecontaineragent_dbus_stub.cpp
+++ b/agent/src/softwarecontaineragent_dbus_stub.cpp
@@ -1,0 +1,322 @@
+#include "softwarecontaineragent_dbus_stub.h"
+
+Glib::ustring interfaceXml0 = R"XML_DELIMITER(
+<?xml version="1.0" encoding="UTF-8" ?>
+<node name="/com/pelagicore/SoftwareContainer">
+    <interface name="com.pelagicore.SoftwareContainerAgent">
+        <method name="List">
+            <arg direction="out" type="ai" name="containers" />
+        </method>
+
+        <method name="Create">
+            <arg direction="in" type="s" name="config" />
+            <arg direction="out" type="i" name="containerID" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <method name="Execute">
+            <arg direction="in" type="i" name="containerID" />
+            <arg direction="in" type="s" name="commandLine" />
+            <arg direction="in" type="s" name="workingDirectory" />
+            <arg direction="in" type="s" name="outputFile" />
+            <arg direction="in" type="a{ss}" name="env" />
+            <arg direction="out" type="i" name="pid" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <method name="Suspend">
+            <arg direction="in" type="i" name="containerID" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <method name="Resume">
+            <arg direction="in" type="i" name="containerID" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <method name="Destroy">
+            <arg direction="in" type="i" name="containerID" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <method name="BindMount">
+            <arg direction="in" type="i" name="containerID" />
+            <arg direction="in" type="s" name="pathInHost" />
+            <arg direction="in" type="s" name="pathInContainer" />
+            <arg direction="in" type="b" name="readOnly" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <method name="ListCapabilities">
+            <arg direction="out" type="as" name="capabilities" />
+        </method>
+
+        <method name="SetCapabilities">
+            <arg direction="in" type="i" name="containerID" />
+            <arg direction="in" type="as" name="capabilities" />
+            <arg direction="out" type="b" name="success" />
+        </method>
+
+        <signal name="ProcessStateChanged">
+            <arg direction="out" type="i" name="containerID"/>
+            <arg direction="out" type="u" name="processID"/>
+            <arg direction="out" type="b" name="isRunning"/>
+            <arg direction="out" type="u" name="exitCode"/>
+        </signal>
+
+    </interface>
+</node>
+)XML_DELIMITER";
+
+com::pelagicore::SoftwareContainerAgent::SoftwareContainerAgent() : connectionId(0), registeredId(0), m_objectPath("/com/pelagicore/SoftwareContainerAgent"), m_interfaceName("com.pelagicore.SoftwareContainerAgent") {
+
+    ProcessStateChanged_signal.connect(sigc::mem_fun(this, &SoftwareContainerAgent::ProcessStateChanged_emitter));
+
+}
+void com::pelagicore::SoftwareContainerAgent::connect (
+    Gio::DBus::BusType busType,
+    std::string name)
+{
+    try {
+            introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
+    } catch(const Glib::Error& ex) {
+            g_warning("Unable to create introspection data: ");
+            g_warning(std::string(ex.what()).c_str());
+            g_warning("\n");
+    }
+    connectionId = Gio::DBus::own_name(busType,
+                                       name,
+                                       sigc::mem_fun(this, &SoftwareContainerAgent::on_bus_acquired),
+                                       sigc::mem_fun(this, &SoftwareContainerAgent::on_name_acquired),
+                                       sigc::mem_fun(this, &SoftwareContainerAgent::on_name_lost));
+}
+
+void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+                   const Glib::ustring& /* sender */,
+                   const Glib::ustring& /* object_path */,
+                   const Glib::ustring& /* interface_name */,
+                   const Glib::ustring& method_name,
+                   const Glib::VariantContainerBase& parameters,
+                   const Glib::RefPtr<Gio::DBus::MethodInvocation>& invocation)
+{
+
+    if (method_name.compare("List") == 0) {
+        List(
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("Create") == 0) {
+        Glib::Variant<Glib::ustring > base_config;
+        parameters.get_child(base_config, 0);
+        Glib::ustring p_config;
+        p_config = base_config.get();
+
+        Create(
+            Glib::ustring(p_config),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("Execute") == 0) {
+        Glib::Variant<gint32 > base_containerID;
+        parameters.get_child(base_containerID, 0);
+        gint32 p_containerID;
+        p_containerID = base_containerID.get();
+
+        Glib::Variant<Glib::ustring > base_commandLine;
+        parameters.get_child(base_commandLine, 1);
+        Glib::ustring p_commandLine;
+        p_commandLine = base_commandLine.get();
+
+        Glib::Variant<Glib::ustring > base_workingDirectory;
+        parameters.get_child(base_workingDirectory, 2);
+        Glib::ustring p_workingDirectory;
+        p_workingDirectory = base_workingDirectory.get();
+
+        Glib::Variant<Glib::ustring > base_outputFile;
+        parameters.get_child(base_outputFile, 3);
+        Glib::ustring p_outputFile;
+        p_outputFile = base_outputFile.get();
+
+        Glib::Variant<std::map<Glib::ustring, Glib::ustring> > base_env;
+        parameters.get_child(base_env, 4);
+        std::map<Glib::ustring, Glib::ustring> p_env;
+        p_env = base_env.get();
+
+        Execute(
+            (p_containerID),
+            Glib::ustring(p_commandLine),
+            Glib::ustring(p_workingDirectory),
+            Glib::ustring(p_outputFile),
+            SoftwareContainerAgentCommon::glibStringMapToStdStringMap(p_env),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("Suspend") == 0) {
+        Glib::Variant<gint32 > base_containerID;
+        parameters.get_child(base_containerID, 0);
+        gint32 p_containerID;
+        p_containerID = base_containerID.get();
+
+        Suspend(
+            (p_containerID),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("Resume") == 0) {
+        Glib::Variant<gint32 > base_containerID;
+        parameters.get_child(base_containerID, 0);
+        gint32 p_containerID;
+        p_containerID = base_containerID.get();
+
+        Resume(
+            (p_containerID),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("Destroy") == 0) {
+        Glib::Variant<gint32 > base_containerID;
+        parameters.get_child(base_containerID, 0);
+        gint32 p_containerID;
+        p_containerID = base_containerID.get();
+
+        Destroy(
+            (p_containerID),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("BindMount") == 0) {
+        Glib::Variant<gint32 > base_containerID;
+        parameters.get_child(base_containerID, 0);
+        gint32 p_containerID;
+        p_containerID = base_containerID.get();
+
+        Glib::Variant<Glib::ustring > base_pathInHost;
+        parameters.get_child(base_pathInHost, 1);
+        Glib::ustring p_pathInHost;
+        p_pathInHost = base_pathInHost.get();
+
+        Glib::Variant<Glib::ustring > base_pathInContainer;
+        parameters.get_child(base_pathInContainer, 2);
+        Glib::ustring p_pathInContainer;
+        p_pathInContainer = base_pathInContainer.get();
+
+        Glib::Variant<bool > base_readOnly;
+        parameters.get_child(base_readOnly, 3);
+        bool p_readOnly;
+        p_readOnly = base_readOnly.get();
+
+        BindMount(
+            (p_containerID),
+            Glib::ustring(p_pathInHost),
+            Glib::ustring(p_pathInContainer),
+            (p_readOnly),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("ListCapabilities") == 0) {
+        ListCapabilities(
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    if (method_name.compare("SetCapabilities") == 0) {
+        Glib::Variant<gint32 > base_containerID;
+        parameters.get_child(base_containerID, 0);
+        gint32 p_containerID;
+        p_containerID = base_containerID.get();
+
+        Glib::Variant<std::vector<Glib::ustring> > base_capabilities;
+        parameters.get_child(base_capabilities, 1);
+        std::vector<Glib::ustring> p_capabilities;
+        p_capabilities = base_capabilities.get();
+
+        SetCapabilities(
+            (p_containerID),
+            SoftwareContainerAgentCommon::glibStringVecToStdStringVec(p_capabilities),
+            SoftwareContainerAgentMessageHelper(invocation));
+    }
+    }
+
+void com::pelagicore::SoftwareContainerAgent::on_interface_get_property(Glib::VariantBase& property,
+                      const Glib::RefPtr<Gio::DBus::Connection>& connection,
+                      const Glib::ustring& sender,
+                      const Glib::ustring& object_path,
+                      const Glib::ustring& interface_name,
+                      const Glib::ustring& property_name) {
+
+}
+
+bool com::pelagicore::SoftwareContainerAgent::on_interface_set_property(
+       const Glib::RefPtr<Gio::DBus::Connection>& connection,
+       const Glib::ustring& sender,
+       const Glib::ustring& object_path,
+       const Glib::ustring& interface_name,
+       const Glib::ustring& property_name,
+       const Glib::VariantBase& value) {
+
+
+    return true;
+}
+
+void com::pelagicore::SoftwareContainerAgent::ProcessStateChanged_emitter(gint32 containerID, guint32 processID, bool isRunning, guint32 exitCode) {
+            std::vector<Glib::VariantBase> paramsList;
+
+paramsList.push_back(Glib::Variant<gint32 >::create((containerID)));;
+
+
+paramsList.push_back(Glib::Variant<guint32 >::create((processID)));;
+
+
+paramsList.push_back(Glib::Variant<bool >::create((isRunning)));;
+
+
+paramsList.push_back(Glib::Variant<guint32 >::create((exitCode)));;
+
+m_connection->emit_signal(
+              "/com/pelagicore/SoftwareContainerAgent",
+              "com.pelagicore.SoftwareContainerAgent",
+              "ProcessStateChanged",
+              Glib::ustring(),
+              Glib::Variant<std::vector<Glib::VariantBase> >::create_tuple(paramsList));
+      }
+
+void com::pelagicore::SoftwareContainerAgent::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection>& connection,
+                         const Glib::ustring& /* name */) {
+    Gio::DBus::InterfaceVTable *interface_vtable =
+          new Gio::DBus::InterfaceVTable(
+                sigc::mem_fun(this, &SoftwareContainerAgent::on_method_call),
+                sigc::mem_fun(this, &SoftwareContainerAgent::on_interface_get_property),
+                sigc::mem_fun(this, &SoftwareContainerAgent::on_interface_set_property));
+    try {
+        registeredId = connection->register_object(m_objectPath,
+            introspection_data->lookup_interface("com.pelagicore.SoftwareContainerAgent"),
+            *interface_vtable);
+        m_connection = connection;
+    }
+    catch(const Glib::Error& ex) {
+        g_warning("Registration of object failed");
+    }
+
+    return;
+}
+void com::pelagicore::SoftwareContainerAgent::on_name_acquired(const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+                      const Glib::ustring& /* name */) {}
+
+void com::pelagicore::SoftwareContainerAgent::on_name_lost(const Glib::RefPtr<Gio::DBus::Connection>& connection,
+                  const Glib::ustring& /* name */) {}
+
+
+bool com::pelagicore::SoftwareContainerAgent::emitSignal(const std::string& propName, Glib::VariantBase& value) {
+    std::map<Glib::ustring, Glib::VariantBase> changedProps;
+    std::vector<Glib::ustring> changedPropsNoValue;
+
+    changedProps[propName] = value;
+
+    Glib::Variant<std::map<Glib::ustring,  Glib::VariantBase> > changedPropsVar = Glib::Variant<std::map <Glib::ustring, Glib::VariantBase> >::create (changedProps);
+    Glib::Variant<std::vector<Glib::ustring> > changedPropsNoValueVar = Glib::Variant<std::vector<Glib::ustring> >::create(changedPropsNoValue);
+    std::vector<Glib::VariantBase> ps;
+    ps.push_back(Glib::Variant<Glib::ustring>::create(m_interfaceName));
+    ps.push_back(changedPropsVar);
+    ps.push_back(changedPropsNoValueVar);
+    Glib::VariantContainerBase propertiesChangedVariant = Glib::Variant<std::vector<Glib::VariantBase> >::create_tuple(ps);
+
+    m_connection->emit_signal(
+        m_objectPath,
+        "org.freedesktop.DBus.Properties",
+        "PropertiesChanged",
+        Glib::ustring(),
+        propertiesChangedVariant);
+
+    return true;
+}

--- a/agent/src/softwarecontaineragent_dbus_stub.h
+++ b/agent/src/softwarecontaineragent_dbus_stub.h
@@ -1,0 +1,105 @@
+#pragma once
+#include <string>
+#include <glibmm.h>
+#include <giomm.h>
+
+#include "softwarecontaineragent_dbus_common.h"
+
+
+namespace com {
+namespace pelagicore {
+class SoftwareContainerAgent {
+public:
+    SoftwareContainerAgent ();
+    void connect (Gio::DBus::BusType, std::string);
+
+protected:
+    virtual void List (
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void Create (
+        std::string config,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void Execute (
+        gint32 containerID,
+        std::string commandLine,
+        std::string workingDirectory,
+        std::string outputFile,
+        std::map<std::string, std::string>  env,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void Suspend (
+        gint32 containerID,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void Resume (
+        gint32 containerID,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void Destroy (
+        gint32 containerID,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void BindMount (
+        gint32 containerID,
+        std::string pathInHost,
+        std::string pathInContainer,
+        bool readOnly,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void ListCapabilities (
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    virtual void SetCapabilities (
+        gint32 containerID,
+        std::vector<std::string>  capabilities,
+        const SoftwareContainerAgentMessageHelper msg) = 0;
+
+    void ProcessStateChanged_emitter(gint32, guint32, bool, guint32);
+    sigc::signal<void, gint32, guint32, bool, guint32 > ProcessStateChanged_signal;
+
+    void on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection>& connection,
+                         const Glib::ustring& /* name */);
+
+    void on_name_acquired(const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+                          const Glib::ustring& /* name */);
+
+    void on_name_lost(const Glib::RefPtr<Gio::DBus::Connection>& connection,
+                      const Glib::ustring& /* name */);
+
+    void on_method_call(const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+                        const Glib::ustring& /* sender */,
+                        const Glib::ustring& /* object_path */,
+                        const Glib::ustring& /* interface_name */,
+                        const Glib::ustring& method_name,
+                        const Glib::VariantContainerBase& parameters,
+                        const Glib::RefPtr<Gio::DBus::MethodInvocation>& invocation);
+
+    void on_interface_get_property(Glib::VariantBase& property,
+                                   const Glib::RefPtr<Gio::DBus::Connection>& connection,
+                                   const Glib::ustring& sender,
+                                   const Glib::ustring& object_path,
+                                   const Glib::ustring& interface_name,
+                                   const Glib::ustring& property_name);
+
+    bool on_interface_set_property(
+           const Glib::RefPtr<Gio::DBus::Connection>& connection,
+           const Glib::ustring& sender,
+           const Glib::ustring& object_path,
+           const Glib::ustring& interface_name,
+           const Glib::ustring& property_name,
+           const Glib::VariantBase& value);
+
+private:
+bool emitSignal(const std::string& propName, Glib::VariantBase& value);
+
+guint connectionId, registeredId;
+Glib::RefPtr<Gio::DBus::NodeInfo> introspection_data;
+Glib::RefPtr<Gio::DBus::Connection> m_connection;
+std::string m_objectPath;
+std::string m_interfaceName;
+};
+}// pelagicore
+}// com
+

--- a/agent/src/softwarecontaineragentadaptor.h
+++ b/agent/src/softwarecontaineragentadaptor.h
@@ -20,63 +20,49 @@
 #pragma once
 
 #include "softwarecontaineragent.h"
+#include "softwarecontaineragent_dbus_stub.h"
 
 namespace softwarecontainer {
 
 class SoftwareContainerAgentAdaptor :
-    public com::pelagicore::SoftwareContainerAgent_adaptor
+    public ::com::pelagicore::SoftwareContainerAgent
 {
     LOG_DECLARE_CLASS_CONTEXT("SCAA", "SoftwareContainerAgentAdaptor");
 
 public:
     virtual ~SoftwareContainerAgentAdaptor();
 
-    SoftwareContainerAgentAdaptor(SoftwareContainerAgent &agent);
+    SoftwareContainerAgentAdaptor(::softwarecontainer::SoftwareContainerAgent &agent, bool useSessionBus);
 
-    std::vector<int32_t> List() override;
-    std::vector<std::string> ListCapabilities() override;
+    void List(SoftwareContainerAgentMessageHelper msg) override;
+    void ListCapabilities(SoftwareContainerAgentMessageHelper msg) override;
 
-    void Execute(const int32_t &containerID,
-                 const std::string &commandLine,
-                 const std::string &workingDirectory,
-                 const std::string &outputFile,
-                 const std::map<std::string, std::string> &env,
-                 int32_t &pid,
-                 bool &success);
+    void Execute(const gint32 containerID,
+                 const std::string commandLine,
+                 const std::string workingDirectory,
+                 const std::string outputFile,
+                 const std::map<std::string, std::string> env,
+                 SoftwareContainerAgentMessageHelper msg) override;
 
-    bool Destroy(const int32_t &containerID) override;
+    void Destroy(const gint32 containerID, SoftwareContainerAgentMessageHelper msg) override;
 
-    bool BindMount(const int32_t &containerID,
-                   const std::string &pathInHost,
-                   const std::string &PathInContainer,
-                   const bool &readOnly) override;
+    void BindMount(const gint32 containerID,
+                   const std::string pathInHost,
+                   const std::string PathInContainer,
+                   const bool readOnly,
+                   SoftwareContainerAgentMessageHelper msg) override;
 
-    bool Suspend(const int32_t &containerID) override;
+    void Suspend(const gint32 containerID, SoftwareContainerAgentMessageHelper msg) override;
 
-    bool Resume(const int32_t &containerID) override;
+    void Resume(const gint32 containerID, SoftwareContainerAgentMessageHelper msg) override;
 
-    bool SetCapabilities(const int32_t &containerID,
-                         const std::vector<std::string> &capabilities) override;
+    void SetCapabilities(const gint32 containerID,
+                         const std::vector<std::string> capabilities,
+                         SoftwareContainerAgentMessageHelper msg) override;
 
-    void Create(const std::string &config, int32_t &containerID, bool &success) override;
+    void Create(const std::string config, SoftwareContainerAgentMessageHelper msg) override;
 
-    SoftwareContainerAgent &m_agent;
+    ::softwarecontainer::SoftwareContainerAgent &m_agent;
 
 };
 }
-
-
-// Utility class for DBus Adaptors
-class DBusCppAdaptor : public SoftwareContainerAgentAdaptor,
-                       public DBus::IntrospectableAdaptor,
-                       public DBus::ObjectAdaptor {
-public:
-    DBusCppAdaptor(DBus::Connection &connection,
-                   const std::string &objectPath,
-                   SoftwareContainerAgent &agent) :
-        SoftwareContainerAgentAdaptor(agent),
-        DBus::ObjectAdaptor(connection, objectPath)
-    {
-    }
-};
-

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,12 @@
 # Unset RPATH. This should not be needed for any example.
 set(CMAKE_INSTALL_RPATH "")
 
+pkg_check_modules(DBusCpp REQUIRED dbus-c++-glib-1>=0.9.0)
+
+add_definitions(${DBusCpp_CFLAGS_OTHER})
+include_directories(${DBusCpp_INCLUDE_DIRS})
+link_directories(${DBusCpp_LIBRARY_DIRS})
+
 add_subdirectory(simple)
 add_subdirectory(temperature)
 add_subdirectory(wayland)


### PR DESCRIPTION
This pull-request attempts to remove dbus-c++ and replace it with giomm dbus bindings instead.
The stubs for the new bindings were generated with a giomm dbus binding generator. However, it was not complete so that some changes had to be made later. In order to make transition, if the generator is patched, to generating at build time, I have chosen to change as little as possible of the generated code. Due to this fact there might be some redundant code and I ask you to please have that in mind when reviewing the pr.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>