### PR TITLE
namespaces everything to "softwarecontainer"

### DIFF
--- a/agent/component-test/main.cpp
+++ b/agent/component-test/main.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 
 #include "ivi-logging-console.h"
 #include "softwarecontainer-common.h"
+
+using namespace softwarecontainer;
 
 LOG_DEFINE_APP_IDS("PCON", "SoftwareContainer Unit Test");
 LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context");

--- a/agent/component-test/softwarecontaineragent_unittest.cpp
+++ b/agent/component-test/softwarecontaineragent_unittest.cpp
@@ -24,6 +24,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+using namespace softwarecontainer;
+
 /*
  * Test stub - StringConfigLoader
  *

--- a/agent/src/capability/baseconfigstore.cpp
+++ b/agent/src/capability/baseconfigstore.cpp
@@ -19,6 +19,8 @@
 
 #include "baseconfigstore.h"
 
+namespace softwarecontainer {
+
 BaseConfigStore::BaseConfigStore(const std::string &inputPath)
 {
     ReturnCode retval = ReturnCode::SUCCESS;
@@ -220,3 +222,5 @@ bool BaseConfigStore::isJsonFile(const std::string &filename) {
     }
     return filename.substr(filename.size()-5) == ".json";
 }
+
+} // namespace softwarecontainer

--- a/agent/src/capability/baseconfigstore.h
+++ b/agent/src/capability/baseconfigstore.h
@@ -111,4 +111,5 @@ private:
     bool isJsonFile(const std::string &filename);
 
 };
-}
+
+} // namespace softwarecontainer

--- a/agent/src/capability/defaultconfigstore.cpp
+++ b/agent/src/capability/defaultconfigstore.cpp
@@ -19,6 +19,8 @@
 
 #include "defaultconfigstore.h"
 
+namespace softwarecontainer {
+
 DefaultConfigStore::DefaultConfigStore(const std::string &path):BaseConfigStore(path)
 {
 }
@@ -36,3 +38,5 @@ GatewayConfiguration DefaultConfigStore::configs()
 
    return conf;
 }
+
+} // namespace softwarecontainer

--- a/agent/src/capability/defaultconfigstore.h
+++ b/agent/src/capability/defaultconfigstore.h
@@ -31,4 +31,5 @@ public:
 
     GatewayConfiguration configs();
 };
-}
+
+} // namespace softwarecontainer

--- a/agent/src/capability/filteredconfigstore.cpp
+++ b/agent/src/capability/filteredconfigstore.cpp
@@ -19,6 +19,8 @@
 
 #include "filteredconfigstore.h"
 
+namespace softwarecontainer {
+
 FilteredConfigStore::FilteredConfigStore(const std::string &path): BaseConfigStore(path)
 {
 }
@@ -58,3 +60,5 @@ GatewayConfiguration FilteredConfigStore::configByID(const std::string &capID) c
 
     return m_capMap.at(capID);
 }
+
+} // namespace softwarecontainer

--- a/agent/src/capability/filteredconfigstore.h
+++ b/agent/src/capability/filteredconfigstore.h
@@ -53,4 +53,5 @@ public:
     GatewayConfiguration configByID(const std::string &capID) const;
 
 };
-}
+
+} // namespace softwarecontainer

--- a/agent/src/config/config.cpp
+++ b/agent/src/config/config.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -19,7 +18,6 @@
  */
 
 #include "config.h"
-
 
 namespace softwarecontainer {
 

--- a/agent/src/config/config.h
+++ b/agent/src/config/config.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -28,7 +27,6 @@
 #include "configloaderabstractinterface.h"
 #include "configdefaults.h"
 #include "mandatoryconfigs.h"
-
 
 namespace softwarecontainer {
 

--- a/agent/src/config/configdefaults.cpp
+++ b/agent/src/config/configdefaults.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,10 +17,10 @@
  * For further information see LICENSE
  */
 
-
 #include "config/configdefaults.h"
 #include "config/config.h"
 
+namespace softwarecontainer {
 
 ConfigDefaults::ConfigDefaults():
     m_stringOptions(std::map<std::string, std::string>()),
@@ -61,3 +60,5 @@ bool ConfigDefaults::getValue(const std::string &key) const
 {
     return m_boolOptions.at(key);
 }
+
+} // namespace softwarecontainer

--- a/agent/src/config/configdefaults.h
+++ b/agent/src/config/configdefaults.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -22,6 +21,7 @@
 
 #include "softwarecontainer-common.h"
 
+namespace softwarecontainer {
 
 class ConfigDefaults
 {
@@ -40,3 +40,5 @@ protected:
     std::map<std::string, int> m_intOptions;
     std::map<std::string, bool> m_boolOptions;
 };
+
+} // namespace softwarecontainer

--- a/agent/src/config/configloaderabstractinterface.h
+++ b/agent/src/config/configloaderabstractinterface.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,8 +17,9 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
+
+namespace softwarecontainer {
 
 /*
  * Abstract interface to a concrete loader.
@@ -42,3 +42,5 @@ protected:
     // A string with the source of the config, e.g. a path or config string.
     std::string m_source;
 };
+
+} // namespace softwarecontainer

--- a/agent/src/config/fileconfigloader.cpp
+++ b/agent/src/config/fileconfigloader.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,9 +17,9 @@
  * For further information see LICENSE
  */
 
-
 #include "fileconfigloader.h"
 
+namespace softwarecontainer {
 
 std::unique_ptr<Glib::KeyFile> FileConfigLoader::loadConfig()
 {
@@ -40,3 +39,5 @@ std::unique_ptr<Glib::KeyFile> FileConfigLoader::loadConfig()
 
     return configData;
 }
+
+} // namespace softwarecontainer

--- a/agent/src/config/fileconfigloader.h
+++ b/agent/src/config/fileconfigloader.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,13 +17,14 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
 
 #include <glibmm.h>
 
 #include "softwarecontainer-common.h"
 #include "configloaderabstractinterface.h"
+
+namespace softwarecontainer {
 
 class FileConfigLoader : public ConfigLoaderAbstractInterface
 {
@@ -37,3 +37,5 @@ public:
 
     std::unique_ptr<Glib::KeyFile> loadConfig() override;
 };
+
+} // namespace softwarecontainer

--- a/agent/src/config/mandatoryconfigs.cpp
+++ b/agent/src/config/mandatoryconfigs.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -20,6 +19,7 @@
 
 #include "mandatoryconfigs.h"
 
+namespace softwarecontainer {
 
 MandatoryConfigs::MandatoryConfigs():
     m_configs(std::vector<std::tuple<std::string, std::string, ConfigType>>()),
@@ -44,3 +44,5 @@ std::vector<std::string> MandatoryConfigs::groups()
 {
     return m_groups;
 }
+
+} // namespace softwarecontainer

--- a/agent/src/config/mandatoryconfigs.h
+++ b/agent/src/config/mandatoryconfigs.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -21,7 +20,6 @@
 #pragma once
 
 #include "softwarecontainer-common.h"
-
 
 namespace softwarecontainer {
 

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -17,7 +17,6 @@
  * For further information see LICENSE
  */
 
-
 #include <glibmm/optioncontext.h>
 
 #include "config/config.h"
@@ -27,12 +26,14 @@
 
 #include "softwarecontaineragentadaptor.h"
 
+namespace softwarecontainer {
 
 LOG_DEFINE_APP_IDS("SCAG", "SoftwareContainer agent");
+LOG_DECLARE_DEFAULT_CONTEXT(PAM_DefaultLogContext, "MAIN", "Main context");
 
-namespace softwarecontainer {
-    LOG_DECLARE_DEFAULT_CONTEXT(PAM_DefaultLogContext, "MAIN", "Main context");
-}
+} // namespace softwarecontainer
+
+using namespace softwarecontainer;
 
 /*
  * When we get signals that can be trapped, we want the main loop to be quitted.
@@ -43,6 +44,7 @@ int signalHandler(void *data) {
     (*ml)->quit();
     return 0;
 }
+
 
 int main(int argc, char **argv)
 {
@@ -202,7 +204,6 @@ int main(int argc, char **argv)
 
         Config config(std::move(loader), std::move(defaults), stringOptions, intOptions, boolOptions);
 
-        static constexpr const char *AGENT_OBJECT_PATH = "/com/pelagicore/SoftwareContainerAgent";
         ::softwarecontainer::SoftwareContainerAgent agent(mainContext, config);
         std::unique_ptr<SoftwareContainerAgentAdaptor> adaptor( new SoftwareContainerAgentAdaptor(agent, useSessionBus));
 
@@ -221,3 +222,4 @@ int main(int argc, char **argv)
         return 1;
     }
 }
+

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -20,6 +20,7 @@
 #include "softwarecontaineragent.h"
 #include <cstdint>
 
+namespace softwarecontainer {
 
 SoftwareContainerAgent::SoftwareContainerAgent(
         Glib::RefPtr<Glib::MainContext> mainLoopContext,
@@ -467,3 +468,5 @@ std::shared_ptr<Workspace> SoftwareContainerAgent::getWorkspace()
 {
     return m_softwarecontainerWorkspace;
 }
+
+} // namespace softwarecontainer

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -258,4 +258,5 @@ private:
     std::shared_ptr<FilteredConfigStore> m_filteredConfigStore;
     std::shared_ptr<DefaultConfigStore>  m_defaultConfigStore;
 };
-}
+
+} // namespace softwarecontainer

--- a/agent/src/softwarecontaineragentadaptor.cpp
+++ b/agent/src/softwarecontaineragentadaptor.cpp
@@ -98,4 +98,4 @@ void SoftwareContainerAgentAdaptor::Create(const std::string config,
     msg.ret(containerID, success);
 }
 
-} // End namespace softwarecontainer
+} // namespace softwarecontainer

--- a/agent/src/softwarecontaineragentadaptor.h
+++ b/agent/src/softwarecontaineragentadaptor.h
@@ -65,4 +65,6 @@ public:
     ::softwarecontainer::SoftwareContainerAgent &m_agent;
 
 };
-}
+
+} // namespace softwarecontainer
+

--- a/agent/unit-test/config_unittest.cpp
+++ b/agent/unit-test/config_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -29,6 +28,7 @@
 #include <string>
 #include <glibmm.h>
 
+using namespace softwarecontainer;
 
 /*
  * Test stub - StringConfigLoader

--- a/agent/unit-test/configstore_unittest.cpp
+++ b/agent/unit-test/configstore_unittest.cpp
@@ -26,6 +26,8 @@
 #include <unistd.h>
 #include <libgen.h>
 
+using namespace softwarecontainer;
+
 class ConfigStoreTest: public ::testing::Test
 {
 public:

--- a/agent/unit-test/main.cpp
+++ b/agent/unit-test/main.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 
 #include "ivi-logging-console.h"
 #include "softwarecontainer-common.h"
+
+using namespace softwarecontainer;
 
 LOG_DEFINE_APP_IDS("PCON", "SoftwareContainer Unit Test");
 LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context");

--- a/common/cleanuphandler.h
+++ b/common/cleanuphandler.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -37,4 +36,4 @@ public:
     virtual const std::string queryName() = 0;
 };
 
-}
+} // namespace softwarecontainer

--- a/common/directorycleanuphandler.cpp
+++ b/common/directorycleanuphandler.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -19,6 +18,8 @@
  */
 
 #include "directorycleanuphandler.h"
+
+namespace softwarecontainer {
 
 DirectoryCleanUpHandler::DirectoryCleanUpHandler(const std::string &path)
 {
@@ -45,3 +46,5 @@ const std::string DirectoryCleanUpHandler::queryName()
 {
     return m_path;
 }
+
+} // namespace softwarecontainer

--- a/common/directorycleanuphandler.h
+++ b/common/directorycleanuphandler.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -22,6 +21,8 @@
 
 #include <cleanuphandler.h>
 
+namespace softwarecontainer {
+
 class DirectoryCleanUpHandler :
     public CleanUpHandler
 {
@@ -39,3 +40,5 @@ public:
 
     std::string m_path;
 };
+
+} // namespace softwarecontainer

--- a/common/filecleanuphandler.cpp
+++ b/common/filecleanuphandler.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -20,6 +19,8 @@
 
 #include "filecleanuphandler.h"
 
+namespace softwarecontainer {
+
 FileCleanUpHandler::FileCleanUpHandler(const std::string &path)
 {
     m_path = path;
@@ -40,3 +41,5 @@ const std::string FileCleanUpHandler::queryName()
 {
     return m_path;
 }
+
+} // namespace softwarecontainer

--- a/common/filecleanuphandler.h
+++ b/common/filecleanuphandler.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -21,6 +20,8 @@
 #pragma once
 
 #include <cleanuphandler.h>
+
+namespace softwarecontainer {
 
 /**
  * @brief The FileCleanUpHandler class is a subclass of CleanUpHandler that deletes a file. It is
@@ -54,3 +55,5 @@ public:
 
     std::string m_path;
 };
+
+} // namespace softwarecontainer

--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -286,4 +285,4 @@ ReturnCode FileToolkitWithUndo::createSymLink(
     return ReturnCode::SUCCESS;
 }
 
-}
+} // namespace softwarecontainer

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -132,4 +131,4 @@ private :
     ReturnCode createParentDirectory(const std::string &path);
 };
 
-}
+} // namespace softwarecontainer

--- a/common/gatewayconfig.cpp
+++ b/common/gatewayconfig.cpp
@@ -19,6 +19,8 @@
 
 #include "gatewayconfig.h"
 
+namespace softwarecontainer {
+
 GatewayConfiguration::GatewayConfiguration()
 {
 }
@@ -89,3 +91,5 @@ bool GatewayConfiguration::empty()
 {
     return m_configMap.empty();
 }
+
+} // namespace softwarecontainer

--- a/common/gatewayconfig.h
+++ b/common/gatewayconfig.h
@@ -23,6 +23,8 @@
 #include "jansson.h"
 #include "softwarecontainer-common.h"
 
+namespace softwarecontainer {
+
 class GatewayConfiguration {
     LOG_DECLARE_CLASS_CONTEXT("GWCF", "GatewayConfig");
 
@@ -41,3 +43,4 @@ private:
     std::map<std::string, json_t *> m_configMap;
 };
 
+} // namespace softwarecontainer

--- a/common/ivi-profiling.h
+++ b/common/ivi-profiling.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/common/jsonparser.cpp
+++ b/common/jsonparser.cpp
@@ -104,4 +104,4 @@ bool JSONParser::hasKey(const json_t *element, const char *key)
     return json_object_get(element, key) != NULL;
 }
 
-}
+} // namespace softwarecontainer

--- a/common/jsonparser.h
+++ b/common/jsonparser.h
@@ -95,4 +95,4 @@ namespace softwarecontainer {
          */
         static bool hasKey(const json_t *element, const char *key);
     };
-}
+} // namespace softwarecontainer

--- a/common/mountcleanuphandler.cpp
+++ b/common/mountcleanuphandler.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -19,8 +18,9 @@
  */
 
 #include "mountcleanuphandler.h"
-
 #include <sys/mount.h>
+
+namespace softwarecontainer {
 
 MountCleanUpHandler::MountCleanUpHandler(const std::string &path)
 {
@@ -48,3 +48,5 @@ const std::string MountCleanUpHandler::queryName()
 {
     return "";
 }
+
+} // namespace softwarecontainer

--- a/common/mountcleanuphandler.h
+++ b/common/mountcleanuphandler.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -22,6 +21,8 @@
 
 #include <cleanuphandler.h>
 
+namespace softwarecontainer {
+
 class MountCleanUpHandler :
     public CleanUpHandler
 {
@@ -44,3 +45,5 @@ public:
 
     std::string m_path;
 };
+
+} // namespace softwarecontainer

--- a/common/overlaysynccleanuphandler.cpp
+++ b/common/overlaysynccleanuphandler.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -22,6 +21,8 @@
 
 #include "recursivecopy.h"
 
+namespace softwarecontainer {
+
 OverlaySyncCleanupHandler::OverlaySyncCleanupHandler(std::string src, std::string dst)
 {
     m_src = src;
@@ -37,3 +38,5 @@ const std::string OverlaySyncCleanupHandler::queryName()
 {
     return "";
 }
+
+} // namespace softwarecontainer

--- a/common/overlaysynccleanuphandler.h
+++ b/common/overlaysynccleanuphandler.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -21,6 +20,8 @@
 #pragma once
 
 #include <cleanuphandler.h>
+
+namespace softwarecontainer {
 
 /**
  * @brief The OverlaySyncCleanupHandler class is used to copy files on cleanup and can be added to the
@@ -60,3 +61,5 @@ private:
     std::string m_dst;
 
 };
+
+} // namespace softwarecontainer

--- a/common/recursivecopy.cpp
+++ b/common/recursivecopy.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+
+namespace softwarecontainer {
 
 std::string dstRoot;
 std::string srcRoot;
@@ -90,3 +91,5 @@ ReturnCode RecursiveCopy::copy(std::string src, std::string dst)
 RecursiveCopy::RecursiveCopy() { }
 
 RecursiveCopy::~RecursiveCopy() { }
+
+} // namespace softwarecontainer

--- a/common/recursivecopy.h
+++ b/common/recursivecopy.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -21,6 +20,7 @@
 #pragma once
 #include "softwarecontainer-common.h"
 
+namespace softwarecontainer {
 
 /**
  * @brief The RecursiveCopy class is a singleton class used to copy files recursively from a
@@ -62,3 +62,5 @@ private:
      */
     std::mutex m_copyLock;
 };
+
+} // namespace softwarecontainer

--- a/common/signalconnectionshandler.cpp
+++ b/common/signalconnectionshandler.cpp
@@ -32,4 +32,4 @@ SignalConnectionsHandler::~SignalConnectionsHandler()
     }
 }
 
-}
+} // namespace softwarecontainer

--- a/common/signalconnectionshandler.h
+++ b/common/signalconnectionshandler.h
@@ -66,4 +66,4 @@ inline void addProcessListener(
     connections.addConnection(connection);
 }
 
-} // end namespace
+} // namespace softwarecontainer

--- a/common/softwarecontainer-common.cpp
+++ b/common/softwarecontainer-common.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -169,7 +168,5 @@ bool parseInt(const char *arg, int *result)
     return true;
 }
 
-} // end namespace
-
-
+} // namespace softwarecontainer
 

--- a/common/softwarecontainer-common.h
+++ b/common/softwarecontainer-common.h
@@ -147,6 +147,4 @@ ReturnCode writeToFile(const std::string &path, const std::string &content);
 ReturnCode readFromFile(const std::string &path, std::string &content);
 bool parseInt(const char *args, int *result);
 
-}
-
-using namespace softwarecontainer;
+} // namespace softwarecontainer;

--- a/common/softwarecontainer-log.h
+++ b/common/softwarecontainer-log.h
@@ -23,4 +23,4 @@
 
 namespace softwarecontainer {
     typedef logging::DefaultLogContext LogContext;
-}
+} // namespace softwarecontainer

--- a/common/unit-test/main.cpp
+++ b/common/unit-test/main.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 
 #include "ivi-logging-console.h"
 #include "softwarecontainer-common.h"
+
+using namespace softwarecontainer;
 
 LOG_DEFINE_APP_IDS("PCON", "SoftwareContainer Unit Test");
 LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context");

--- a/common/unit-test/recursivecopy_unittest.cpp
+++ b/common/unit-test/recursivecopy_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -27,6 +26,7 @@
 #include <unistd.h>
 #include <fstream>
 
+using namespace softwarecontainer;
 
 class RecursiveCopyTest: public ::testing::Test
 {

--- a/common/unit-test/softwarecontainer-common_unittest.cpp
+++ b/common/unit-test/softwarecontainer-common_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -23,6 +22,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <unistd.h>
+
+using namespace softwarecontainer;
 
 class SoftwareContainerCommonTest: public ::testing::Test
 {

--- a/libsoftwarecontainer/component-test/cgroupsgateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/cgroupsgateway_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/dbusgateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/dbusgateway_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/devicenodegateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/devicenodegateway_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/filegateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/filegateway_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/main.cpp
+++ b/libsoftwarecontainer/component-test/main.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 
 #include "ivi-logging-console.h"
 #include "softwarecontainer-common.h"
+
+using namespace softwarecontainer;
 
 LOG_DEFINE_APP_IDS("PCON", "SoftwareContainer Unit Test");
 LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context");

--- a/libsoftwarecontainer/component-test/netlink_unittest.cpp
+++ b/libsoftwarecontainer/component-test/netlink_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/networkgateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/networkgateway_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.h
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -30,6 +29,8 @@
 
 #include "gateway.h"
 #include "softwarecontainer.h"
+
+using namespace softwarecontainer;
 
 class SoftwareContainerTest : public ::testing::Test
 {

--- a/libsoftwarecontainer/component-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainerlib_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/include/commandjob.h
+++ b/libsoftwarecontainer/include/commandjob.h
@@ -18,7 +18,9 @@
  */
 
 #pragma once
+
 #include "jobabstract.h"
+
 namespace softwarecontainer {
 
 /**
@@ -42,4 +44,5 @@ private:
     std::string m_command;
     std::string m_workingDirectory;
 };
-}
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/container.h
+++ b/libsoftwarecontainer/include/container.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -29,6 +28,8 @@
 
 #include "softwarecontainer-common.h"
 #include "containerabstractinterface.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief The Container class is an abstraction of the specific containment technology used.
@@ -267,3 +268,4 @@ private:
     ContainerState m_state = ContainerState::DEFAULT;
 };
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/containerabstractinterface.h
+++ b/libsoftwarecontainer/include/containerabstractinterface.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -22,6 +21,8 @@
 #pragma once
 
 #include "softwarecontainer-common.h"
+
+namespace softwarecontainer {
 
 class ContainerAbstractInterface {
 
@@ -94,3 +95,5 @@ public:
                                           int stderr = 2) = 0;
 
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/functionjob.h
+++ b/libsoftwarecontainer/include/functionjob.h
@@ -16,8 +16,11 @@
  *
  * For further information see LICENSE
  */
+
 #pragma once
+
 #include "jobabstract.h"
+
 namespace softwarecontainer {
 
 /**
@@ -40,4 +43,5 @@ public:
 private:
     std::function<int()> m_command;
 };
-}
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/gateway.h
+++ b/libsoftwarecontainer/include/gateway.h
@@ -205,4 +205,4 @@ private:
 
 };
 
-} // end namespace
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/jobabstract.h
+++ b/libsoftwarecontainer/include/jobabstract.h
@@ -17,9 +17,11 @@
  * For further information see LICENSE
  */
 #pragma once
+
 #include "softwarecontainer.h"
 
 namespace softwarecontainer {
+
 /**
  * Abstract class for jobs which get executed inside a container
  */
@@ -63,4 +65,5 @@ protected:
     int m_stdout[2] = {UNASSIGNED_STREAM, UNASSIGNED_STREAM};
     int m_stderr[2] = {UNASSIGNED_STREAM, UNASSIGNED_STREAM};
 };
-}
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/netlink.h
+++ b/libsoftwarecontainer/include/netlink.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+namespace softwarecontainer {
+
 /**
  * @brief Handles various network operations over netlink
  *
@@ -303,3 +305,4 @@ class Netlink
         bool m_netlinkInitialized;
 };
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -122,4 +121,5 @@ private:
 
     bool m_initialized = false;
 };
-}
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/workspace.h
+++ b/libsoftwarecontainer/include/workspace.h
@@ -62,4 +62,4 @@ public:
     unsigned int m_containerShutdownTimeout;
 };
 
-}
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -41,6 +40,8 @@
 
 #include "container.h"
 #include "filecleanuphandler.h"
+
+namespace softwarecontainer {
 
 static constexpr const char *LXC_CONTAINERS_ROOT_CONFIG_ITEM = "lxc.lxcpath";
 
@@ -779,3 +780,5 @@ const std::string &Container::rootFS() const
 {
     return m_rootFSPath;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/cgroups/cgroupsgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/cgroups/cgroupsgateway.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,12 +17,13 @@
  * For further information see LICENSE
  */
 
-
 #include "jansson.h"
 
 #include "softwarecontainer-common.h"
 #include "cgroupsgateway.h"
 #include "cgroupsparser.h"
+
+namespace softwarecontainer {
 
 CgroupsGateway::CgroupsGateway()
     : Gateway(ID)
@@ -64,3 +64,5 @@ bool CgroupsGateway::teardownGateway()
 {
     return true;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/cgroups/cgroupsgateway.h
+++ b/libsoftwarecontainer/src/gateway/cgroups/cgroupsgateway.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -23,6 +22,8 @@
 
 #include "gateway.h"
 
+namespace softwarecontainer {
+
 /**
  * @brief The cgroups gateway sets cgroups related settings for the container.
  */
@@ -44,3 +45,5 @@ public:
 private:
     std::map<std::string, std::string> m_settings;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/cgroups/cgroupsparser.cpp
+++ b/libsoftwarecontainer/src/gateway/cgroups/cgroupsparser.cpp
@@ -1,6 +1,26 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
 
 #include "cgroupsparser.h"
 #include "jsonparser.h"
+
+namespace softwarecontainer {
 
 ReturnCode CGroupsParser::parseCGroupsGatewayConfiguration(const json_t *element, CGroupsPair &result)
 {
@@ -21,3 +41,5 @@ ReturnCode CGroupsParser::parseCGroupsGatewayConfiguration(const json_t *element
     result.second = settingValue;
     return ReturnCode::SUCCESS;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/cgroups/cgroupsparser.h
+++ b/libsoftwarecontainer/src/gateway/cgroups/cgroupsparser.h
@@ -1,8 +1,28 @@
+/*
+ * Copyright (C) 2016 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
 
 #pragma once
 
 #include "softwarecontainer-common.h"
 #include <jansson.h>
+
+namespace softwarecontainer {
 
 class CGroupsParser
 {
@@ -14,3 +34,5 @@ public:
     ReturnCode parseCGroupsGatewayConfiguration(const json_t *element, CGroupsPair &result);
 
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgateway.cpp
@@ -20,6 +20,8 @@
 #include "dbusgateway.h"
 #include "gatewayparsererror.h"
 
+namespace softwarecontainer {
+
 DBusGateway::DBusGateway(const std::string &gatewayDir, const std::string &name):
     Gateway(ID),
     sessionBus(DBusGatewayInstance::ProxyType::SessionProxy, gatewayDir, name),
@@ -114,3 +116,5 @@ bool DBusGateway::isActivated()
 {
     return sessionBus.isActivated() || systemBus.isActivated();
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgateway.h
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgateway.h
@@ -22,6 +22,8 @@
 #include "gateway.h"
 #include "dbusgatewayinstance.h"
 
+namespace softwarecontainer {
+
 class DBusGateway : public Gateway
 {
     LOG_DECLARE_CLASS_CONTEXT("DBUS", "DBus gateway");
@@ -67,3 +69,5 @@ private:
     DBusGatewayInstance sessionBus;
     DBusGatewayInstance systemBus;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,9 +17,10 @@
  * For further information see LICENSE
  */
 
-
 #include "dbusgateway.h"
 #include "dbusgatewayparser.h"
+
+namespace softwarecontainer {
 
 DBusGatewayInstance::DBusGatewayInstance(ProxyType type
                        , const std::string &gatewayDir
@@ -226,4 +226,4 @@ std::string DBusGatewayInstance::socketName()
     return socket.substr(socket.rfind('/') + 1);
 }
 
-
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.h
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -21,6 +20,8 @@
 #pragma once
 
 #include "gateway.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief DBus Gateway takes care of spawning and killing the DBus proxies.
@@ -122,3 +123,4 @@ private:
     virtual bool testDBusConnection(const std::string &config);
 };
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayparser.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayparser.cpp
@@ -20,6 +20,8 @@
 #include "dbusgatewayparser.h"
 #include "gatewayparsererror.h"
 
+namespace softwarecontainer {
+
 ReturnCode DBusGatewayParser::parseDBusConfig(const json_t *element,
                                               const char *key,
                                               json_t *config)
@@ -53,3 +55,5 @@ void DBusGatewayParser::throwWithLog(std::string message)
     log_error() << message;
     throw GatewayParserError(message);
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayparser.h
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayparser.h
@@ -22,6 +22,8 @@
 #include "softwarecontainer-common.h"
 #include "jsonparser.h"
 
+namespace softwarecontainer {
+
 class DBusGatewayParser
 {
     LOG_DECLARE_CLASS_CONTEXT("DBGP", "D-Bus gateway parser");
@@ -32,3 +34,5 @@ public:
 private:
     void throwWithLog(std::string message);
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -23,6 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+namespace softwarecontainer {
 
 DeviceNodeGateway::DeviceNodeGateway() :
     Gateway(ID)
@@ -103,3 +103,5 @@ ReturnCode DeviceNodeGateway::applySettings()
     }
     return ReturnCode::SUCCESS;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -25,6 +24,8 @@
 #include "softwarecontainer-common.h"
 #include "gateway.h"
 #include "devicenodelogic.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief This gateway is responsible for exposing device nodes in an LXC container.
@@ -78,3 +79,5 @@ private:
 
     DeviceNodeLogic m_logic;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -19,6 +18,8 @@
  */
 
 #include "devicenodelogic.h"
+
+namespace softwarecontainer {
 
 std::vector<DeviceNodeParser::Device>::iterator
 DeviceNodeLogic::findDeviceByName(const std::string name)
@@ -74,3 +75,4 @@ int DeviceNodeLogic::calculateDeviceMode(const int storedMode, const int applied
     return mode;
 }
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -19,8 +18,11 @@
  */
 
 #pragma once
+
 #include "softwarecontainer-common.h"
 #include "devicenodeparser.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief This class is responsible for storing all device node configurations
@@ -70,3 +72,5 @@ public:
 private:
     std::vector<DeviceNodeParser::Device> m_devList;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.cpp
@@ -19,6 +19,8 @@
 
 #include "devicenodeparser.h"
 
+namespace softwarecontainer {
+
 ReturnCode DeviceNodeParser::parseDeviceNodeGatewayConfiguration(const json_t *element,
                                                                  Device &result)
 {
@@ -54,3 +56,5 @@ bool DeviceNodeParser::checkBoolSet(const bool &value, std::string errorMessage)
 
     return true;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -23,6 +22,8 @@
 #include "softwarecontainer-common.h"
 #include "jsonparser.h"
 
+namespace softwarecontainer {
+
 class DeviceNodeParser
 {
     LOG_DECLARE_CLASS_CONTEXT("DNGP", "Device node gateway parser");
@@ -42,3 +43,4 @@ private:
     bool checkBoolSet(const bool &value, std::string errorMessage);
 };
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/environment/envgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/environment/envgateway.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,12 +17,13 @@
  * For further information see LICENSE
  */
 
-
 #include <string>
 #include <unistd.h>
 
 #include "envgateway.h"
 #include "envgatewayparser.h"
+
+namespace softwarecontainer {
 
 EnvironmentGateway::EnvironmentGateway() :
     Gateway(ID)
@@ -69,3 +69,5 @@ bool EnvironmentGateway::teardownGateway()
 {
     return true;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/environment/envgateway.h
+++ b/libsoftwarecontainer/src/gateway/environment/envgateway.h
@@ -17,9 +17,10 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
 #include "gateway.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief Environment Gateway is used to define environment variables to the container
@@ -41,3 +42,5 @@ public:
 private:
     EnvironmentVariables m_variables;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/environment/envgatewayparser.cpp
+++ b/libsoftwarecontainer/src/gateway/environment/envgatewayparser.cpp
@@ -19,6 +19,8 @@
 
 #include "envgatewayparser.h"
 
+namespace softwarecontainer {
+
 ReturnCode EnvironmentGatewayParser::parseEnvironmentGatewayConfigElement(
     const json_t *element,
     EnvironmentVariable &result,
@@ -92,3 +94,4 @@ ReturnCode EnvironmentGatewayParser::requireNonEmptyKeyValue(const json_t *eleme
     return ReturnCode::SUCCESS;
 }
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/environment/envgatewayparser.h
+++ b/libsoftwarecontainer/src/gateway/environment/envgatewayparser.h
@@ -22,6 +22,8 @@
 #include "softwarecontainer-common.h"
 #include "jsonparser.h"
 
+namespace softwarecontainer {
+
 class EnvironmentGatewayParser
 {
     LOG_DECLARE_CLASS_CONTEXT("ENVP", "Environment gateway parser");
@@ -36,3 +38,5 @@ private:
                                        const std::string key,
                                        std::string &result);
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/files/filegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/files/filegateway.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,8 +17,9 @@
  * For further information see LICENSE
  */
 
-
 #include "filegateway.h"
+
+namespace softwarecontainer {
 
 FileGateway::FileGateway()
     : Gateway(ID)
@@ -80,3 +80,5 @@ bool FileGateway::teardownGateway()
 {
     return true;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/files/filegateway.h
+++ b/libsoftwarecontainer/src/gateway/files/filegateway.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,7 +17,6 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
 
 #include <string>
@@ -27,6 +25,8 @@
 #include "gateway.h"
 #include "filegatewayparser.h"
 #include "filegatewaysettingstore.h"
+
+namespace softwarecontainer {
 
 /**
  * This gateway lets you map files (including socket files) or folders
@@ -51,3 +51,5 @@ private:
 
     FileGatewaySettingStore m_store;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/files/filegatewayparser.cpp
+++ b/libsoftwarecontainer/src/gateway/files/filegatewayparser.cpp
@@ -20,6 +20,8 @@
 #include "filegatewayparser.h"
 #include "jsonparser.h"
 
+namespace softwarecontainer {
+
 ReturnCode FileGatewayParser::parseConfigElement(const json_t *element, FileSetting &setting)
 {
     if (!JSONParser::read(element, "path-host", setting.pathInHost)) {
@@ -49,3 +51,5 @@ ReturnCode FileGatewayParser::parseConfigElement(const json_t *element, FileSett
 
     return ReturnCode::SUCCESS;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/files/filegatewayparser.h
+++ b/libsoftwarecontainer/src/gateway/files/filegatewayparser.h
@@ -22,6 +22,8 @@
 #include "softwarecontainer-common.h"
 #include <jansson.h>
 
+namespace softwarecontainer {
+
 class FileGatewayParser
 {
     LOG_DECLARE_CLASS_CONTEXT("FILP", "File gateway parser");
@@ -41,3 +43,5 @@ public:
      */
     ReturnCode parseConfigElement(const json_t *element, FileSetting &setting);
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/files/filegatewaysettingstore.cpp
+++ b/libsoftwarecontainer/src/gateway/files/filegatewaysettingstore.cpp
@@ -19,6 +19,8 @@
 
 #include "filegatewaysettingstore.h"
 
+namespace softwarecontainer {
+
 FileGatewaySettingStore::FileGatewaySettingStore()
     : m_settings({})
 {
@@ -51,3 +53,5 @@ const std::vector<FileGatewayParser::FileSetting> &FileGatewaySettingStore::getS
 {
     return m_settings;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/files/filegatewaysettingstore.h
+++ b/libsoftwarecontainer/src/gateway/files/filegatewaysettingstore.h
@@ -21,6 +21,8 @@
 
 #include "filegatewayparser.h"
 
+namespace softwarecontainer {
+
 class FileGatewaySettingStore
 {
     LOG_DECLARE_CLASS_CONTEXT("FGWR", "File Gateway Rule Engine");
@@ -56,3 +58,5 @@ private:
     // The internal storage of settings
     std::vector<FileGatewayParser::FileSetting> m_settings;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/gateway.cpp
+++ b/libsoftwarecontainer/src/gateway/gateway.cpp
@@ -19,6 +19,7 @@
 
 #include "gateway.h"
 
+namespace softwarecontainer {
 
 ReturnCode Gateway::setConfig(const std::string &config)
 {
@@ -175,3 +176,5 @@ ReturnCode Gateway::executeInContainer(ContainerFunction func)
         return ReturnCode::FAILURE;
     }
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/gatewayparsererror.h
+++ b/libsoftwarecontainer/src/gateway/gatewayparsererror.h
@@ -46,4 +46,4 @@ private:
 
 };
 
-} // end namespace
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/iptableentry.cpp
+++ b/libsoftwarecontainer/src/gateway/network/iptableentry.cpp
@@ -20,6 +20,8 @@
 #include "iptableentry.h"
 #include "gateway.h"
 
+namespace softwarecontainer {
+
 ReturnCode IPTableEntry::applyRules()
 {
     for (auto rule : m_rules) {
@@ -174,3 +176,5 @@ ReturnCode IPTableEntry::insertCommand(std::string command)
 
     return ReturnCode::SUCCESS;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/iptableentry.h
+++ b/libsoftwarecontainer/src/gateway/network/iptableentry.h
@@ -21,6 +21,8 @@
 
 #include "softwarecontainer-common.h"
 
+namespace softwarecontainer {
+
 /**
  * @brief A rules entry for the treatment of packets.
  */
@@ -113,3 +115,4 @@ private:
     ReturnCode insertCommand(std::string command);
 };
 
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/netlink.cpp
+++ b/libsoftwarecontainer/src/gateway/network/netlink.cpp
@@ -24,6 +24,8 @@
 #include <unistd.h> // getpid(), getpagesize()
 #include <string.h> // memcpy, memset etc
 
+namespace softwarecontainer {
+
 Netlink::Netlink()
 {
     m_sequenceNumber = 1;
@@ -559,3 +561,5 @@ void Netlink::clearCache()
 
     m_hasKernelDump = false;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/networkgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/network/networkgateway.cpp
@@ -17,12 +17,13 @@
  * For further information see LICENSE
  */
 
-
 #include <cstring>
 #include "ifaddrs.h"
 #include "unistd.h"
 #include "networkgateway.h"
 #include "networkgatewayparser.h"
+
+namespace softwarecontainer {
 
 NetworkGateway::NetworkGateway(const int32_t id,
                                const std::string gateway,
@@ -223,3 +224,5 @@ ReturnCode NetworkGateway::isBridgeAvailable()
 
     return m_netlinkHost.hasAddress(addresses, AF_INET, m_gateway.c_str());
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/networkgateway.h
+++ b/libsoftwarecontainer/src/gateway/network/networkgateway.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 #include "jansson.h"
 #include "netlink.h"
 #include "iptableentry.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief Sets up and manages network access and routing to the container
@@ -131,3 +132,5 @@ private:
     int32_t m_containerID;
     Netlink m_netlinkHost;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/networkgatewayparser.cpp
+++ b/libsoftwarecontainer/src/gateway/network/networkgatewayparser.cpp
@@ -18,6 +18,8 @@
  */
 #include "networkgatewayparser.h"
 
+namespace softwarecontainer {
+
 ReturnCode NetworkGatewayParser::parseNetworkGatewayConfiguration(const json_t *element, IPTableEntry &e)
 {
     std::string chain;
@@ -179,3 +181,5 @@ ReturnCode NetworkGatewayParser::parseProtocol(const json_t *element,
     }
     return ReturnCode::SUCCESS;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/network/networkgatewayparser.h
+++ b/libsoftwarecontainer/src/gateway/network/networkgatewayparser.h
@@ -23,6 +23,7 @@
 #include "iptableentry.h"
 #include "jsonparser.h"
 
+namespace softwarecontainer {
 
 class NetworkGatewayParser
 {
@@ -72,3 +73,5 @@ private :
     IPTableEntry::Target parseTarget(const std::string &str);
 
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/pulsegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -19,6 +18,8 @@
  */
 
 #include "pulsegateway.h"
+
+namespace softwarecontainer {
 
 PulseGateway::PulseGateway() :
     Gateway(ID),
@@ -85,3 +86,5 @@ bool PulseGateway::teardownGateway()
 {
     return true;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/pulsegateway.h
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,10 +17,11 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
 
 #include "gateway.h"
+
+namespace softwarecontainer {
 
 /**
  * @brief The PulseAudio Gateway is used to provide access to the host system PulseAudio server.
@@ -66,3 +66,5 @@ private:
     */
     virtual ReturnCode enablePulseAudio();
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/waylandgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,10 +17,11 @@
  * For further information see LICENSE
  */
 
-
 #include <string>
 #include <unistd.h>
 #include "waylandgateway.h"
+
+namespace softwarecontainer {
 
 // These lines are needed in order to define the fields, which otherwise would
 // yield linker errors.
@@ -88,3 +88,5 @@ bool WaylandGateway::teardownGateway()
 {
     return true;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/waylandgateway.h
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,10 +17,11 @@
  * For further information see LICENSE
  */
 
-
 #pragma once
 
 #include "gateway.h"
+
+namespace softwarecontainer {
 
 class WaylandGateway :
     public Gateway
@@ -44,3 +44,5 @@ public:
 private:
     bool m_enabled;
 };
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/jobs/commandjob.cpp
+++ b/libsoftwarecontainer/src/jobs/commandjob.cpp
@@ -19,6 +19,8 @@
 
 #include "commandjob.h"
 
+namespace softwarecontainer {
+
 CommandJob::CommandJob(
     SoftwareContainer &sc, const std::string &command): JobAbstract(sc)
 {
@@ -47,3 +49,5 @@ std::string CommandJob::toString() const
                                     << m_command << " stdin:" << m_stdin[0]
                                     << " stdout:" << m_stdout[1];
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/jobs/functionjob.cpp
+++ b/libsoftwarecontainer/src/jobs/functionjob.cpp
@@ -19,6 +19,8 @@
 
 #include "functionjob.h"
 
+namespace softwarecontainer {
+
 FunctionJob::FunctionJob(
     SoftwareContainer &sc, std::function<int()> command): JobAbstract(sc)
 {
@@ -47,3 +49,5 @@ std::string FunctionJob::toString() const
                                     << " stdin:" << m_stdin[0]
                                     << " stdout:" << m_stdout[1];
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/jobs/jobabstract.cpp
+++ b/libsoftwarecontainer/src/jobs/jobabstract.cpp
@@ -19,6 +19,8 @@
 
 #include "jobabstract.h"
 
+namespace softwarecontainer {
+
 JobAbstract::JobAbstract(SoftwareContainer &sc) :
     m_sc(sc)
 {
@@ -94,3 +96,5 @@ void JobAbstract::setEnvironmentVariables(const EnvironmentVariables &env)
 {
     m_env = env;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -326,4 +326,4 @@ ObservableProperty<ContainerState> &SoftwareContainer::getContainerState()
     return m_containerState;
 }
 
-}
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/workspace.cpp
+++ b/libsoftwarecontainer/src/workspace.cpp
@@ -19,6 +19,8 @@
 
 #include "workspace.h"
 
+namespace softwarecontainer {
+
 Workspace::Workspace()
 {
     // Make sure path ends in '/' since it might not always be checked
@@ -74,3 +76,5 @@ ReturnCode Workspace::checkWorkspace()
 
     return ReturnCode::SUCCESS;
 }
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/unit-test/cgroupsparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/cgroupsparser_unittest.cpp
@@ -20,6 +20,8 @@
 #include "gateway/cgroups/cgroupsparser.h"
 #include "gateway_parser_common.h"
 
+using namespace softwarecontainer;
+
 class CGroupsParserTest : public GatewayParserCommon<std::string>
 {
 public:

--- a/libsoftwarecontainer/unit-test/dbusgatewayparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/dbusgatewayparser_unittest.cpp
@@ -23,6 +23,8 @@
 
 #include "gateway_parser_common.h"
 
+using namespace softwarecontainer;
+
 class DBusGatewayParserTest : public GatewayParserCommon<std::string>
 {
 

--- a/libsoftwarecontainer/unit-test/devicenodelogic_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodelogic_unittest.cpp
@@ -25,6 +25,8 @@
 #include <unistd.h>
 #include <libgen.h>
 
+using namespace softwarecontainer;
+
 struct testModes
 {
     int itemMode;

--- a/libsoftwarecontainer/unit-test/devicenodeparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodeparser_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,9 +17,10 @@
  * For further information see LICENSE
  */
 
-
 #include "gateway/devicenode/devicenodeparser.h"
 #include "gateway_parser_common.h"
+
+using namespace softwarecontainer;
 
 class DeviceNodeParserTest : public GatewayParserCommon<std::string>
 {

--- a/libsoftwarecontainer/unit-test/envgatewayparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/envgatewayparser_unittest.cpp
@@ -17,9 +17,10 @@
  * For further information see LICENSE
  */
 
-
 #include "gateway/environment/envgatewayparser.h"
 #include "gateway_parser_common.h"
+
+using namespace softwarecontainer;
 
 class EnvGatewayParserTest : public GatewayParserCommon<std::string>
 {

--- a/libsoftwarecontainer/unit-test/filegatewayparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/filegatewayparser_unittest.cpp
@@ -20,6 +20,8 @@
 #include "gateway/files/filegatewayparser.h"
 #include "gateway_parser_common.h"
 
+using namespace softwarecontainer;
+
 class FileGatewayParserTest : public GatewayParserCommon<std::string>
 {
 public:

--- a/libsoftwarecontainer/unit-test/filegatewaysettingstore_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/filegatewaysettingstore_unittest.cpp
@@ -22,6 +22,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using namespace softwarecontainer;
+
 class FileGatewaySettingStoreTest : public ::testing::Test
 {
 public:

--- a/libsoftwarecontainer/unit-test/gateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/gateway_unittest.cpp
@@ -23,6 +23,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using namespace softwarecontainer;
+
 class MockGateway : public Gateway
 {
 public:

--- a/libsoftwarecontainer/unit-test/iptableentry_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/iptableentry_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -18,10 +17,11 @@
  * For further information see LICENSE
  */
 
-
 #include "gateway/network/iptableentry.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using namespace softwarecontainer;
 
 class MockIPTableEntry :
     public IPTableEntry

--- a/libsoftwarecontainer/unit-test/main.cpp
+++ b/libsoftwarecontainer/unit-test/main.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -24,6 +23,8 @@
 
 #include "ivi-logging-console.h"
 #include "softwarecontainer-common.h"
+
+using namespace softwarecontainer;
 
 LOG_DEFINE_APP_IDS("PCON", "SoftwareContainer Unit Test");
 LOG_DECLARE_CONTEXT(SoftwareContainer_DefaultLogContext, "PCON", "Main context");

--- a/libsoftwarecontainer/unit-test/networkgatewayparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/networkgatewayparser_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *
@@ -25,6 +24,8 @@
 #include "gateway_parser_common.h"
 
 #include <jansson.h>
+
+using namespace softwarecontainer;
 
 class NetworkGatewayParserTest : public GatewayParserCommon<std::string>
 {

--- a/libsoftwarecontainer/unit-test/obsolete/devicenodegateway_unittest_data.h
+++ b/libsoftwarecontainer/unit-test/obsolete/devicenodegateway_unittest_data.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/unit-test/obsolete/generators_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/obsolete/generators_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/unit-test/obsolete/pulsegateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/obsolete/pulsegateway_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/unit-test/obsolete/pulsegateway_unittest_data.h
+++ b/libsoftwarecontainer/unit-test/obsolete/pulsegateway_unittest_data.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/unit-test/obsolete/softwarecontainer_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/obsolete/softwarecontainer_unittest.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2016 Pelagicore AB
  *

--- a/libsoftwarecontainer/unit-test/pulsegateway_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/pulsegateway_unittest.cpp
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 #include "gmock/gmock.h"
 
+using namespace softwarecontainer;
+
 class MockPulseGateway :
     public PulseGateway
 {


### PR DESCRIPTION
Instead of namespacing parts and saying "using namespace softwarecontainer" in softwarecontainer-common.h (which everything includes), we now namespace properly.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>