### PR TITLE
Refactor checkContainer to getContainer

### DIFF
--- a/agent/component-test/softwarecontaineragent_unittest.cpp
+++ b/agent/component-test/softwarecontaineragent_unittest.cpp
@@ -132,7 +132,7 @@ TEST_F(SoftwareContainerAgentTest, CreatAndCheckContainer) {
     ContainerID id;
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id) != nullptr);
 }
 
 TEST_F(SoftwareContainerAgentTest, DeleteContainer) {
@@ -142,7 +142,7 @@ TEST_F(SoftwareContainerAgentTest, DeleteContainer) {
     ASSERT_TRUE(success);
     sca->deleteContainer(id);
 
-    ASSERT_FALSE(sca->checkContainer(id, container));
+    ASSERT_FALSE(sca->getContainer(id) != nullptr);
 }
 
 /*
@@ -204,7 +204,7 @@ TEST_F(SoftwareContainerAgentTest, ThawUnfrozenContainer) {
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
 
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id) != nullptr);
 
     ASSERT_FALSE(sca->resumeContainer(id));
 }
@@ -215,7 +215,7 @@ TEST_F(SoftwareContainerAgentTest, FreezeContainerAndThawTwice) {
     ContainerID id;
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id) != nullptr);
 
     ASSERT_TRUE(sca->suspendContainer(id));
 
@@ -230,7 +230,7 @@ TEST_F(SoftwareContainerAgentTest, FreezeFrozenContainer) {
     ContainerID id;
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id) != nullptr);
 
     ASSERT_TRUE(sca->suspendContainer(id));
 
@@ -243,7 +243,7 @@ TEST_F(SoftwareContainerAgentTest, DoubleFreezeContainerAndThaw) {
     ContainerID id;
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id));
 
     ASSERT_TRUE(sca->suspendContainer(id));
 
@@ -258,7 +258,7 @@ TEST_F(SoftwareContainerAgentTest, DoubleFreezeAndDoubleThawContainer) {
     ContainerID id;
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id) != nullptr);
 
     ASSERT_TRUE(sca->suspendContainer(id));
 
@@ -275,7 +275,7 @@ TEST_F(SoftwareContainerAgentTest, ShutdownFrozenContainer) {
     ContainerID id;
     bool success = sca->createContainer(valid_config, id);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(sca->checkContainer(id, container));
+    ASSERT_TRUE(sca->getContainer(id) != nullptr);
 
     ASSERT_TRUE(sca->suspendContainer(id));
 

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -141,15 +141,14 @@ bool SoftwareContainerAgent::deleteContainer(ContainerID containerID)
     return true;
 }
 
-bool SoftwareContainerAgent::checkContainer(ContainerID containerID, SoftwareContainer *&container)
+SoftwareContainer* SoftwareContainerAgent::getContainer(ContainerID containerID)
 {
     if (!isIdValid(containerID)) {
         log_error() << "Invalid container ID " << containerID;
-        return false;
+        return nullptr;
     }
 
-    container = m_containers[containerID].get();
-    return true;
+    return m_containers[containerID].get();
 }
 
 ReturnCode SoftwareContainerAgent::readConfigElement(const json_t *element)
@@ -290,8 +289,8 @@ bool SoftwareContainerAgent::execute(ContainerID containerID,
                                      std::function<void (pid_t, int)> listener)
 {
     profilefunction("executeFunction");
-    SoftwareContainer *container = nullptr;
-    if (!checkContainer(containerID, container)) {
+    SoftwareContainer *container = getContainer(containerID);
+    if (container == nullptr) {
         log_error() << "Invalid container ID " << containerID;
         pid = INVALID_PID;
         return false;
@@ -349,8 +348,8 @@ bool SoftwareContainerAgent::shutdownContainer(ContainerID containerID)
         return false;
     }
 
-    SoftwareContainer *container = nullptr;
-    if (!checkContainer(containerID, container)) {
+    SoftwareContainer *container = getContainer(containerID);
+    if (container == nullptr) {
         log_error() << "Invalid container ID " << containerID;
         return false;
     }
@@ -371,8 +370,8 @@ bool SoftwareContainerAgent::shutdownContainer(ContainerID containerID)
 
 bool SoftwareContainerAgent::suspendContainer(ContainerID containerID)
 {
-    SoftwareContainer *container = nullptr;
-    if (!checkContainer(containerID, container)) {
+    SoftwareContainer *container = getContainer(containerID);
+    if (container == nullptr) {
         log_error() << "Can't suspend container " << containerID;
         return false;
     }
@@ -382,8 +381,8 @@ bool SoftwareContainerAgent::suspendContainer(ContainerID containerID)
 
 bool SoftwareContainerAgent::resumeContainer(ContainerID containerID)
 {
-    SoftwareContainer *container = nullptr;
-    if (!checkContainer(containerID, container)) {
+    SoftwareContainer *container = getContainer(containerID);
+    if (container == nullptr) {
         log_error() << "Can't resume container " << containerID;
         return false;
     }
@@ -397,8 +396,8 @@ bool SoftwareContainerAgent::bindMount(const ContainerID containerID,
                                        bool readOnly)
 {
     profilefunction("bindMountFunction");
-    SoftwareContainer *container = nullptr;
-    if (!checkContainer(containerID, container)) {
+    SoftwareContainer *container = getContainer(containerID);
+    if (container == nullptr) {
         log_error() << "Invalid container ID " << containerID;
         return false;
     }
@@ -418,8 +417,8 @@ bool SoftwareContainerAgent::updateGatewayConfigs(const ContainerID &containerID
                                                   const GatewayConfiguration &configs)
 {
     profilefunction("updateGatewayConfigs");
-    SoftwareContainer *container = nullptr;
-    if (!checkContainer(containerID, container)) {
+    SoftwareContainer *container = getContainer(containerID);
+    if (container == nullptr) {
         log_error() << "Could not update gateway configuration. Container ("
                     << std::to_string(containerID)
                     << ") does not exist";

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -141,14 +141,14 @@ bool SoftwareContainerAgent::deleteContainer(ContainerID containerID)
     return true;
 }
 
-SoftwareContainer* SoftwareContainerAgent::getContainer(ContainerID containerID)
+SoftwareContainerAgent::SoftwareContainerPtr SoftwareContainerAgent::getContainer(ContainerID containerID)
 {
     if (!isIdValid(containerID)) {
         log_error() << "Invalid container ID " << containerID;
         return nullptr;
     }
 
-    return m_containers[containerID].get();
+    return m_containers[containerID];
 }
 
 ReturnCode SoftwareContainerAgent::readConfigElement(const json_t *element)
@@ -289,8 +289,8 @@ bool SoftwareContainerAgent::execute(ContainerID containerID,
                                      std::function<void (pid_t, int)> listener)
 {
     profilefunction("executeFunction");
-    SoftwareContainer *container = getContainer(containerID);
-    if (container == nullptr) {
+    SoftwareContainerPtr container = getContainer(containerID);
+    if (!container) {
         log_error() << "Invalid container ID " << containerID;
         pid = INVALID_PID;
         return false;
@@ -348,8 +348,8 @@ bool SoftwareContainerAgent::shutdownContainer(ContainerID containerID)
         return false;
     }
 
-    SoftwareContainer *container = getContainer(containerID);
-    if (container == nullptr) {
+    SoftwareContainerPtr container = getContainer(containerID);
+    if (!container) {
         log_error() << "Invalid container ID " << containerID;
         return false;
     }
@@ -370,8 +370,8 @@ bool SoftwareContainerAgent::shutdownContainer(ContainerID containerID)
 
 bool SoftwareContainerAgent::suspendContainer(ContainerID containerID)
 {
-    SoftwareContainer *container = getContainer(containerID);
-    if (container == nullptr) {
+    SoftwareContainerPtr container = getContainer(containerID);
+    if (!container) {
         log_error() << "Can't suspend container " << containerID;
         return false;
     }
@@ -381,8 +381,8 @@ bool SoftwareContainerAgent::suspendContainer(ContainerID containerID)
 
 bool SoftwareContainerAgent::resumeContainer(ContainerID containerID)
 {
-    SoftwareContainer *container = getContainer(containerID);
-    if (container == nullptr) {
+    SoftwareContainerPtr container = getContainer(containerID);
+    if (!container) {
         log_error() << "Can't resume container " << containerID;
         return false;
     }
@@ -396,8 +396,8 @@ bool SoftwareContainerAgent::bindMount(const ContainerID containerID,
                                        bool readOnly)
 {
     profilefunction("bindMountFunction");
-    SoftwareContainer *container = getContainer(containerID);
-    if (container == nullptr) {
+    SoftwareContainerPtr container = getContainer(containerID);
+    if (!container) {
         log_error() << "Invalid container ID " << containerID;
         return false;
     }
@@ -417,8 +417,8 @@ bool SoftwareContainerAgent::updateGatewayConfigs(const ContainerID &containerID
                                                   const GatewayConfiguration &configs)
 {
     profilefunction("updateGatewayConfigs");
-    SoftwareContainer *container = getContainer(containerID);
-    if (container == nullptr) {
+    SoftwareContainerPtr container = getContainer(containerID);
+    if (!container) {
         log_error() << "Could not update gateway configuration. Container ("
                     << std::to_string(containerID)
                     << ") does not exist";

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -92,12 +92,12 @@ public:
     bool deleteContainer(ContainerID containerID);
 
     /**
-     * @brief Check whether the given container is valid and return a reference to the actual container
+     * @brief Fetches a pointer to a SoftwareContainer matching an ID.
      *
      * @param containerID the ID for the container
-     * @param container a pointer to a container object (out parameter)
+     * @return Pointer to the matched container if there is such a container. Otherwise return nullptr.
      */
-    bool checkContainer(ContainerID containerID, SoftwareContainer * &container);
+    SoftwareContainer* getContainer(ContainerID containerID);
 
     /**
      * @brief Tries to read a config in json format for a container

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -50,7 +50,7 @@ static constexpr ContainerID INVALID_CONTAINER_ID = -1;
 class SoftwareContainerAgent
 {
     LOG_DECLARE_CLASS_CONTEXT("SCA", "SoftwareContainerAgent");
-    typedef std::unique_ptr<SoftwareContainer> SoftwareContainerPtr;
+    typedef std::shared_ptr<SoftwareContainer> SoftwareContainerPtr;
 
 public:
     /**
@@ -95,9 +95,9 @@ public:
      * @brief Fetches a pointer to a SoftwareContainer matching an ID.
      *
      * @param containerID the ID for the container
-     * @return Pointer to the matched container if there is such a container. Otherwise return nullptr.
+     * @return Pointer to the matched container if there is such a container. Otherwise return empty pointer.
      */
-    SoftwareContainer* getContainer(ContainerID containerID);
+    SoftwareContainerPtr getContainer(ContainerID containerID);
 
     /**
      * @brief Tries to read a config in json format for a container


### PR DESCRIPTION
Refactor checkContainer(id, &container) to getContainer(id) which makes for cleaner code

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>