### PR TITLE
devicenodegateway creates parent paths when needed

### DIFF
--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -263,7 +263,7 @@ ReturnCode FileToolkitWithUndo::writeToFile(const std::string &path, const std::
     return ReturnCode::SUCCESS;
 }
 
-void FileToolkitWithUndo::watchFile(const std::string &path)
+void FileToolkitWithUndo::markFileForDeletion(const std::string &path)
 {
     if (!pathInList(path)) {
         m_cleanupHandlers.push_back(new FileCleanUpHandler(path));

--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -263,6 +263,13 @@ ReturnCode FileToolkitWithUndo::writeToFile(const std::string &path, const std::
     return ReturnCode::SUCCESS;
 }
 
+void FileToolkitWithUndo::watchFile(const std::string &path)
+{
+    if (!pathInList(path)) {
+        m_cleanupHandlers.push_back(new FileCleanUpHandler(path));
+    }
+}
+
 ReturnCode FileToolkitWithUndo::createSymLink(
         const std::string &source,
         const std::string &destination)

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -68,7 +68,7 @@ protected:
      *
      * This is useful if one creates a file in some other way and want it deleted later.
      */
-    void watchFile(const std::string &path);
+    void markFileForDeletion(const std::string &path);
 
     /**
      * @brief overlayMount Mount a directory with an overlay on top of it. An overlay protects

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -45,7 +45,6 @@ public:
             bool readOnly,
             bool enableWriteBuffer=false);
 
-    ReturnCode writeToFile(const std::string &path, const std::string &content);
 
     /**
      * @brief tempDir Creates a temporary directory at templatePath.
@@ -58,6 +57,18 @@ public:
     std::string tempDir(std::string templatePath);
 protected:
     ReturnCode createSymLink(const std::string &source, const std::string &destination);
+
+    /*
+     * @brief Writes to a file (and optionally create it)
+     */
+    ReturnCode writeToFile(const std::string &path, const std::string &content);
+
+    /*
+     * @brief Creates a file cleanup handler for a specific file.
+     *
+     * This is useful if one creates a file in some other way and want it deleted later.
+     */
+    void watchFile(const std::string &path);
 
     /**
      * @brief overlayMount Mount a directory with an overlay on top of it. An overlay protects

--- a/libsoftwarecontainer/component-test/devicenodegateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/devicenodegateway_unittest.cpp
@@ -35,7 +35,7 @@ public:
 
     const std::string NEW_DEVICE = "/tmp/thenewfile";
     const std::string NEW_DEEP_DEVICE = "/tmp/devices/thenewfile";
-    const std::string PRESENT_DEVICE = "/tmp/random";
+    const std::string PRESENT_DEVICE = "/dev/random";
 };
 
 /*
@@ -70,3 +70,22 @@ TEST_F(DeviceNodeGatewayTest, TestActivateWithValidConf) {
     ASSERT_TRUE(isSuccess(gw->activate()));
 }
 
+/*
+ * Make sure we can't re-create or overwrite a device that already exists in the container
+ */
+TEST_F(DeviceNodeGatewayTest, TestOverwriteDeviceFails) {
+    givenContainerIsSet(gw);
+    const std::string config = "[\
+                                  {\
+                                    \"name\": \"" + PRESENT_DEVICE + "\",\
+                                    \"mode\":  \"645\",\
+                                    \"major\": 2,\
+                                    \"minor\": 75,\
+                                    \"mode\":  644\
+                                  }\
+                                ]";
+
+    ASSERT_TRUE(isSuccess(gw->setConfig(config)));
+    ASSERT_FALSE(isSuccess(gw->activate()));
+
+}

--- a/libsoftwarecontainer/component-test/devicenodegateway_unittest.cpp
+++ b/libsoftwarecontainer/component-test/devicenodegateway_unittest.cpp
@@ -34,6 +34,7 @@ public:
     }
 
     const std::string NEW_DEVICE = "/tmp/thenewfile";
+    const std::string NEW_DEEP_DEVICE = "/tmp/devices/thenewfile";
     const std::string PRESENT_DEVICE = "/tmp/random";
 };
 
@@ -45,6 +46,12 @@ TEST_F(DeviceNodeGatewayTest, TestActivateWithValidConf) {
     const std::string config = "[\
                                   {\
                                     \"name\":  \"" + NEW_DEVICE + "\",\
+                                    \"major\": 4,\
+                                    \"minor\": 32,\
+                                    \"mode\":  644\
+                                  },\
+                                  {\
+                                    \"name\":  \"" + NEW_DEEP_DEVICE + "\",\
                                     \"major\": 4,\
                                     \"minor\": 32,\
                                     \"mode\":  644\

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.h
@@ -22,6 +22,7 @@
 #include "jansson.h"
 
 #include "softwarecontainer-common.h"
+#include "filetoolkitwithundo.h"
 #include "gateway/gateway.h"
 #include "devicenodelogic.h"
 
@@ -39,7 +40,8 @@ namespace softwarecontainer {
 *
  */
 class DeviceNodeGateway :
-    public Gateway
+    public Gateway,
+    public FileToolkitWithUndo
 {
     LOG_DECLARE_CLASS_CONTEXT("DNG", "Device node gateway");
 


### PR DESCRIPTION
Otherwise mknod will not work if the parent path does not exist.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>