### PR TITLE
Netw-GW takes values from main config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ if(ENABLE_NETWORKGATEWAY)
     # BRIDGE_NETMASK_BITS is mandatory if we are configured for network
     make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_NETMASK_BITS)
 
-    add_feature_info("Network Bridge Device" TRUE "Network bridge defined as ${SC_CONFIG_GROUP}_${BRIDGE_DEVICE}")
+    add_feature_info("Network Bridge Device" TRUE "Network bridge defined as ${${SC_CONFIG_GROUP}_BRIDGE_DEVICE}")
 
     #
     # Some settings for whether or not SC should create a bridge

--- a/agent/component-test/softwarecontaineragent_unittest.cpp
+++ b/agent/component-test/softwarecontaineragent_unittest.cpp
@@ -83,7 +83,7 @@ public:
                                      "create-bridge = true\n"
                                      "bridge-device = lxcbr0\n"
                                      "bridge-ip = 10.0.3.1\n"
-                                     "bridge-netmask-bits = 24";
+                                     "bridge-netmask-bits = 16";
     const std::string valid_config = "[{\"enableWriteBuffer\": false}]";
 
     void SetUp() override
@@ -95,7 +95,9 @@ public:
         std::vector<std::unique_ptr<ConfigSource>> configSources;
         configSources.push_back(std::move(mainConfig));
 
-        Config config(std::move(configSources), ConfigDefinition::mandatory(), ConfigDependencies());
+        std::shared_ptr<Config> config = std::make_shared<Config>(std::move(configSources),
+                                                                  ConfigDefinition::mandatory(),
+                                                                  ConfigDependencies());
 
         try {
             sca = std::make_shared<SoftwareContainerAgent>(m_context, config);

--- a/agent/src/config/configdefinition.cpp
+++ b/agent/src/config/configdefinition.cpp
@@ -22,13 +22,14 @@
 
 
 /**
- * 
  * Developers guide to adding a config item:
- * TODO: Complete this
+ *
  *   * Add a definition of the string used as key
+ *
  *   * If the config will be possible to set with a command line option, also add
  *     an "intial value" set to something which is possible to use for testing if
  *     the user set it, i.e. an "impossible" value.
+ *
  *   * Add an entry for the config to the CONFIGS data
  */
 
@@ -73,8 +74,6 @@ const std::string ConfigDefinition::SC_BRIDGE_NETMASK_BITS_KEY = "bridge-netmask
 
 
 /*
- * TODO: Document this fully
- *
  * Used to create a mapping between group-key pairs and a type, as well as defining what configs
  * are mandatory.
  *

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -233,7 +233,9 @@ int main(int argc, char **argv)
         configSources.push_back(std::move(mainConfigs));
         configSources.push_back(std::move(defaultConfigs));
 
-        Config config(std::move(configSources), ConfigDefinition::mandatory(), ConfigDependencies());
+        std::shared_ptr<Config> config = std::make_shared<Config>(std::move(configSources),
+                                                                  ConfigDefinition::mandatory(),
+                                                                  ConfigDependencies());
 
         ::softwarecontainer::SoftwareContainerAgent agent(mainContext, config);
         std::unique_ptr<SoftwareContainerAgentAdaptor> adaptor(new SoftwareContainerAgentAdaptor(agent, useSessionBus));

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -65,7 +65,7 @@ public:
      *
      * @throws ReturnCode::FAILURE if initialization of the agent fails
      */
-    SoftwareContainerAgent(Glib::RefPtr<Glib::MainContext> mainLoopContext, const Config &config);
+    SoftwareContainerAgent(Glib::RefPtr<Glib::MainContext> mainLoopContext, std::shared_ptr<Config> config);
 
     ~SoftwareContainerAgent();
 
@@ -259,6 +259,8 @@ private:
 
     std::shared_ptr<FilteredConfigStore> m_filteredConfigStore;
     std::shared_ptr<DefaultConfigStore>  m_defaultConfigStore;
+
+    std::shared_ptr<Config> m_config;
 };
 
 } // namespace softwarecontainer

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -48,7 +48,10 @@ class SoftwareContainer :
 public:
     LOG_DECLARE_CLASS_CONTEXT("PCL", "SoftwareContainer library");
 
-    SoftwareContainer(std::shared_ptr<Workspace> workspace, const ContainerID id);
+    SoftwareContainer(std::shared_ptr<Workspace> workspace,
+                      const ContainerID id,
+                      std::string bridgeIp = "10.0.3.1",
+                      int netmaskBits = 16);
 
     ~SoftwareContainer();
 
@@ -120,8 +123,10 @@ private:
     ReturnCode shutdownGateways();
 
     std::shared_ptr<Workspace> m_workspace;
-
     ContainerID m_containerID;
+    std::string m_bridgeIp;
+    int m_netmaskBits;
+
     ObservableWritableProperty<ContainerState> m_containerState;
 
     std::shared_ptr<ContainerAbstractInterface> m_container;

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -56,9 +56,14 @@
 
 namespace softwarecontainer {
 
-SoftwareContainer::SoftwareContainer(std::shared_ptr<Workspace> workspace, const ContainerID id) :
+SoftwareContainer::SoftwareContainer(std::shared_ptr<Workspace> workspace,
+                                     const ContainerID id,
+                                     std::string bridgeIp,
+                                     int netmaskBits) :
     m_workspace(workspace),
     m_containerID(id),
+    m_bridgeIp(bridgeIp),
+    m_netmaskBits(netmaskBits),
     m_container(new Container("SC-" + std::to_string(id),
                               m_workspace->m_containerConfigPath,
                               m_workspace->m_containerRootDir,
@@ -119,7 +124,7 @@ ReturnCode SoftwareContainer::init()
 
 #ifdef ENABLE_NETWORKGATEWAY
     try {
-        addGateway(new NetworkGateway(m_containerID, "10.0.3.1", 16));
+        addGateway(new NetworkGateway(m_containerID, m_bridgeIp, m_netmaskBits));
     } catch (ReturnCode failure) {
         log_error() << "Given netmask is not appropriate for creating ip address."
                     << "It should be an unsigned value between 1 and 31";


### PR DESCRIPTION
Eventually, the config should probably be passed
to SoftwareContainer, but that has dependencies on some
other structural change which are not part of this commit.
As a middle step towards that, the agent now has the config
as a member but passes the network GW values directly
rather than sharing the config.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>