### PR TITLE
Add exception classes for Agent and ConfigStore

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(softwarecontainer-agent
     ${CMAKE_CURRENT_SOURCE_DIR}/src/capability/baseconfigstore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/capability/defaultconfigstore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/capability/filteredconfigstore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/capability/configstoreerror.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/config/config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/config/fileconfigloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/config/commandlineconfigsource.cpp

--- a/agent/src/capability/baseconfigstore.h
+++ b/agent/src/capability/baseconfigstore.h
@@ -25,6 +25,7 @@
 #pragma once
 #include "softwarecontainer-common.h"
 #include "gatewayconfig.h"
+#include "configstoreerror.h"
 
 #include <jsonparser.h>
 
@@ -40,7 +41,11 @@ public:
      * (of file type json) in the input path, and stores the Capabilities'
      * Gateway configurations.
      *
-     * @throws ReturnCode::FAILURE if parsing of the json file(s) fails
+     * @throws ServiceManifestPathError if the path to the json file(s) is incorrectly formatted
+     * or if the path is not allowed
+     * @throws ServiceManifestParseError if parsing of the json file(s) fails
+     * @throws CapabilityParseError if parsing of one or more Capabilities or Gateway
+     * Configurations in a file is unsuccessful
      */
     BaseConfigStore(const std::string &filePath);
 
@@ -57,11 +62,10 @@ private:
      * If a capability with the same name already exists in the storage
      * the gateways will be appended to the previously stored gatway list.
      *
-     * @return ReturnCode::SUCCESS if successful
-     * @return ReturnCode::FAILURE if parsing of directory or files is unsuccessful
+     * @throws ServiceManifestPathError if the path to the Service Manifest(s) is not allowed
      *
      */
-    virtual ReturnCode readCapsFromDir(const std::string &dirPath);
+    virtual void readCapsFromDir(const std::string &dirPath);
 
     /**
      * @brief Reads a Service Manifest file, of type json, and adds the
@@ -69,29 +73,28 @@ private:
      * If a capability with the same name already exists in the storage
      * the gateways will be appended to the previously stored gatway list.
      *
-     * @return ReturnCode::SUCCESS if successful
-     * @return ReturnCode::FAILURE if parsing of file is unsuccessful
+     * @throws ServiceManifestParseError if parsing of the file is unsuccessful
+     * @throws CapabilityParseError if parsing of one or more Capabilities in file
+     * is unsuccessful
      *
      */
-    virtual ReturnCode readCapsFromFile(const std::string &filePath);
+    virtual void readCapsFromFile(const std::string &filePath);
 
     /**
      * @brief Parse a JSON object, which should be a JSON array, of capabilities
      * and saves them in the internal storage.
      *
-     * @return ReturnCode::SUCCESS if successful
-     * @return ReturnCode::FAILURE if parsing of files is unsuccessful
+     * @throws CapabilityParseError if parsing of Capabilites is unsuccessful
      */
-    ReturnCode parseCapabilities(json_t *capabilities);
+    void parseCapabilities(json_t *capabilities);
 
     /**
      * @brief Parse a JSON object, which should be a JSON array, of gateway configurations
      * and saves them in the internal storage.
      *
-     * @return ReturnCode::SUCCESS if successful
-     * @return ReturnCode::FAILURE if parsing of gateway configurations is unsuccessful
+     * @throws CapabilityParseError if parsing of gateway configurations is unsuccessful
      */
-    ReturnCode parseGatewayConfigs(std::string capName, json_t *gateways);
+    void parseGatewayConfigs(std::string capName, json_t *gateways);
 
     /**
      * @brief Iterates through the files in a directory and finds all json files.

--- a/agent/src/capability/configstoreerror.h
+++ b/agent/src/capability/configstoreerror.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016-2017 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#pragma once
+
+#include "softwarecontainererror.h"
+
+
+namespace softwarecontainer {
+
+class ConfigStoreError : public SoftwareContainerError
+{
+public:
+    ConfigStoreError():
+        m_message("Config Store error")
+    {
+    }
+
+    ConfigStoreError(const std::string &message):
+        m_message(message)
+    {
+    }
+
+    virtual const char *what() const throw()
+    {
+        return m_message.c_str();
+    }
+
+protected:
+    std::string m_message;
+};
+
+/**
+ * @brief An error occured in ConfigStore relating to the path to the Service Manifest(s)
+ *
+ * This exception should be used when the path to the file or directory
+ * pointing to one or more Service Manifests is incorrect.
+ *
+ */
+class ServiceManifestPathError : public ConfigStoreError
+{
+public:
+    ServiceManifestPathError():
+        ConfigStoreError("Service Manifest path error")
+    {
+    }
+
+    ServiceManifestPathError(const std::string &message):
+        ConfigStoreError(message)
+    {
+    }
+
+    virtual const char *what() const throw()
+    {
+        return m_message.c_str();
+    }
+};
+
+/**
+ * @brief An error occured in ConfigStore when parsing a Service Manifest
+ *
+ * This exception should be used when the Service Manifest is incorrectly
+ * formatted, e.g. not a json file.
+ *
+ */
+class ServiceManifestParseError : public ConfigStoreError
+{
+public:
+    ServiceManifestParseError():
+        ConfigStoreError("Config Store error - Service Manifest parse error")
+    {
+    }
+
+    ServiceManifestParseError(const std::string &message):
+        ConfigStoreError(message)
+    {
+    }
+
+    virtual const char *what() const throw()
+    {
+        return m_message.c_str();
+    }
+};
+
+/**
+ * @brief An error occured in ConfigStore when parsing a Capability in a Service Manifest
+ *
+ * This exception should be used when a Capability is incorrectly formatted.
+ *
+ */
+class CapabilityParseError : public ConfigStoreError
+{
+public:
+    CapabilityParseError():
+        ConfigStoreError("Config Store error - Capability parse error")
+    {
+    }
+
+    CapabilityParseError(const std::string &message):
+        ConfigStoreError(message)
+    {
+    }
+
+    virtual const char *what() const throw()
+    {
+        return m_message.c_str();
+    }
+};
+
+} // namespace softwarecontainer

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -232,11 +232,8 @@ int main(int argc, char **argv)
 
         log_debug() << "Exiting softwarecontainer agent";
         return 0;
-    } catch (ConfigError &error) {
-        log_error() << "Could not load configuration";
-        return 1;
-    } catch (ReturnCode failure) {
-        log_error() << "Agent initialization failed";
+    } catch (SoftwareContainerError &error) {
+        log_error() << std::string(error.what());
         return 1;
     }
 }

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -36,51 +36,33 @@ SoftwareContainerAgent::SoftwareContainerAgent(
     m_containerIdPool.push_back(0);
 
     // Get all configs for the workspace
-    int shutdownTimeout;
-    std::string containerRootDir;
-    std::string lxcConfigPath;
-    try {
-        shutdownTimeout = m_config->getIntValue(ConfigDefinition::SC_GROUP,
-                                                ConfigDefinition::SC_SHUTDOWN_TIMEOUT_KEY);
-        containerRootDir = m_config->getStringValue(ConfigDefinition::SC_GROUP,
-                                                    ConfigDefinition::SC_SHARED_MOUNTS_DIR_KEY);
-        lxcConfigPath = m_config->getStringValue(ConfigDefinition::SC_GROUP,
-                                                 ConfigDefinition::SC_LXC_CONFIG_PATH_KEY);
-    } catch (ConfigError &error) {
-        throw ReturnCode::FAILURE;
-    }
+    int shutdownTimeout =
+        m_config->getIntValue(ConfigDefinition::SC_GROUP,
+                              ConfigDefinition::SC_SHUTDOWN_TIMEOUT_KEY);
+    std::string containerRootDir =
+        m_config->getStringValue(ConfigDefinition::SC_GROUP,
+                                 ConfigDefinition::SC_SHARED_MOUNTS_DIR_KEY);
+    std::string lxcConfigPath =
+        m_config->getStringValue(ConfigDefinition::SC_GROUP,
+                                 ConfigDefinition::SC_LXC_CONFIG_PATH_KEY);
 
     // Create and set all values on workspace
-    try {
-        m_softwarecontainerWorkspace = std::make_shared<Workspace>();
-        m_softwarecontainerWorkspace->m_enableWriteBuffer = false;
-        m_softwarecontainerWorkspace->m_containerRootDir = containerRootDir;
-        m_softwarecontainerWorkspace->m_containerConfigPath = lxcConfigPath;
-        m_softwarecontainerWorkspace->m_containerShutdownTimeout = shutdownTimeout;
-    } catch (ReturnCode err) {
-        log_error() << "Failed to set up workspace";
-        throw ReturnCode::FAILURE;
-    }
+    m_softwarecontainerWorkspace = std::make_shared<Workspace>();
+    m_softwarecontainerWorkspace->m_enableWriteBuffer = false;
+    m_softwarecontainerWorkspace->m_containerRootDir = containerRootDir;
+    m_softwarecontainerWorkspace->m_containerConfigPath = lxcConfigPath;
+    m_softwarecontainerWorkspace->m_containerShutdownTimeout = shutdownTimeout;
 
     // Get all configs for the config stores
-    std::string serviceManifestDir;
-    std::string defaultServiceManifestDir;
-    try {
-        serviceManifestDir = m_config->getStringValue(ConfigDefinition::SC_GROUP,
-                                                      ConfigDefinition::SC_SERVICE_MANIFEST_DIR_KEY);
-        defaultServiceManifestDir = m_config->getStringValue(ConfigDefinition::SC_GROUP,
-                                                             ConfigDefinition::SC_DEFAULT_SERVICE_MANIFEST_DIR_KEY);
-    } catch (ConfigError &error) {
-        throw ReturnCode::FAILURE;
-    }
+    std::string serviceManifestDir =
+        m_config->getStringValue(ConfigDefinition::SC_GROUP,
+                                 ConfigDefinition::SC_SERVICE_MANIFEST_DIR_KEY);
+    std::string defaultServiceManifestDir =
+        m_config->getStringValue(ConfigDefinition::SC_GROUP,
+                                 ConfigDefinition::SC_DEFAULT_SERVICE_MANIFEST_DIR_KEY);
+    m_filteredConfigStore = std::make_shared<FilteredConfigStore>(serviceManifestDir);
+    m_defaultConfigStore  = std::make_shared<DefaultConfigStore>(defaultServiceManifestDir);
 
-    try {
-        m_filteredConfigStore = std::make_shared<FilteredConfigStore>(serviceManifestDir);
-        m_defaultConfigStore = std::make_shared<DefaultConfigStore>(defaultServiceManifestDir);
-    } catch (ReturnCode err) {
-        log_error() << "Failed to initialize ConfigStore";
-        throw ReturnCode::FAILURE;
-    }
 }
 
 SoftwareContainerAgent::~SoftwareContainerAgent()

--- a/agent/unit-test/configstore_unittest.cpp
+++ b/agent/unit-test/configstore_unittest.cpp
@@ -73,14 +73,14 @@ TEST_F(ConfigStoreTest, constructorFileOk2) {
  * should throw an exception of type ReturnCode.
  */
 TEST_F(ConfigStoreTest, constructorEvilFile) {
-    ASSERT_THROW(BaseConfigStore(testDataDir + evilManifest), ReturnCode);
+    ASSERT_THROW(BaseConfigStore(testDataDir + evilManifest), CapabilityParseError);
 }
 
 /* Constructing a BaseConfigStore with a directory path,
  * that contains a file that can't be parsed results in an exception.
  */
 TEST_F(ConfigStoreTest, constructorDir) {
-    ASSERT_THROW(BaseConfigStore(testDataDir + ""), ReturnCode);
+    ASSERT_THROW(BaseConfigStore(testDataDir + ""), CapabilityParseError);
 }
 
 /* Constructing a FilteredConfigStore with a directory path,
@@ -96,14 +96,14 @@ TEST_F(ConfigStoreTest, constructorDir2) {
  * when the directory does not exist, should throw an exception of type ReturnCode.
  */
 TEST_F(ConfigStoreTest, constructorEvilDir) {
-    ASSERT_THROW(BaseConfigStore("/home/tester"), ReturnCode);
+    ASSERT_THROW(BaseConfigStore("/home/tester"), ConfigStoreError);
 }
 
 /* Constructing a FilteredConfigStore with a directory path,
  * when the directory is "/", should throw an exception of type ReturnCode.
  */
 TEST_F(ConfigStoreTest, constructorEvilDir2) {
-    ASSERT_THROW(FilteredConfigStore("/"), ReturnCode);
+    ASSERT_THROW(FilteredConfigStore("/"), ServiceManifestPathError);
 }
 
 /* Reading gateway configurations from a Service Manifest file

--- a/common/gatewayconfig.cpp
+++ b/common/gatewayconfig.cpp
@@ -28,7 +28,7 @@ GatewayConfiguration::GatewayConfiguration()
 GatewayConfiguration::GatewayConfiguration(const GatewayConfiguration &gwConf)
 {
     if (isError(append(gwConf))) {
-        throw ReturnCode::FAILURE;
+        throw SoftwareContainerError("Failed to create GatewayConfiguration");
     }
 }
 

--- a/common/gatewayconfig.h
+++ b/common/gatewayconfig.h
@@ -22,6 +22,7 @@
 #include <map>
 #include "jansson.h"
 #include "softwarecontainer-common.h"
+#include "softwarecontainererror.h"
 
 namespace softwarecontainer {
 
@@ -29,8 +30,15 @@ class GatewayConfiguration {
     LOG_DECLARE_CLASS_CONTEXT("GWCF", "GatewayConfig");
 
 public:
+    /**
+     * @brief Creates a new GatewayConfiguration object
+     *
+     * @throws SoftwareContainerError if initialization fails.
+     */
     GatewayConfiguration();
+
     GatewayConfiguration(const GatewayConfiguration &gwConf);
+
     ~GatewayConfiguration();
 
     ReturnCode append(const std::string &id, json_t *conf);

--- a/libsoftwarecontainer/include/workspace.h
+++ b/libsoftwarecontainer/include/workspace.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "filetoolkitwithundo.h"
+#include "softwarecontainererror.h"
 
 namespace softwarecontainer {
 
@@ -37,7 +38,7 @@ public:
     /**
      * @brief Creates a workspace.
      *
-     * @throws ReturnCode::FAILURE if there is an error during the setup.
+     * @throws SoftwareContainerError if there is an error during the setup.
      *
      * @param enableWriteBuffer Enable writebuffers on mountpoints
      * @param containerRootDir The path at which the container resides in the host system

--- a/libsoftwarecontainer/src/gateway/network/networkgateway.h
+++ b/libsoftwarecontainer/src/gateway/network/networkgateway.h
@@ -44,6 +44,11 @@ class NetworkGateway :
 public:
     static constexpr const char *ID = "network";
 
+    /**
+     * @brief Creates a network gateway
+     *
+     * @throws SoftwareContainerError if there is an error during initialization.
+     */
     NetworkGateway(const int32_t id,
                    const std::string gateway,
                    const uint8_t maskBits);

--- a/libsoftwarecontainer/src/workspace.cpp
+++ b/libsoftwarecontainer/src/workspace.cpp
@@ -29,7 +29,7 @@ Workspace::Workspace()
     }
 
     if (isError(checkWorkspace())) {
-        throw ReturnCode::FAILURE;
+        throw SoftwareContainerError("Failed to initialize Workspace");
     }
 }
 


### PR DESCRIPTION
Add ConfigStoreError, which inherits from SoftwareContainerError
Use ConfigStoreError in BaseConfigStore and SoftwareContainerAgent.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>