### PR TITLE
Renamed test file to reflect test level

### DIFF
--- a/agent/component-test/CMakeLists.txt
+++ b/agent/component-test/CMakeLists.txt
@@ -26,7 +26,7 @@ set(AGENT_TEST_LIBRARY_DEPENDENCIES
 
 set(SOFTWARECONTAINERAGENT_TEST_FILES
     main.cpp
-    softwarecontaineragent_unittest.cpp
+    softwarecontaineragent_componenttest.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragent_dbus_common.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragent_dbus_stub.cpp
     ${SOFTWARECONTAINERAGENT_DIR}/src/softwarecontaineragent.cpp

--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -61,14 +61,16 @@ public:
 
 class SoftwareContainerAgentTest: public ::testing::Test
 {
+
+LOG_DECLARE_CLASS_CONTEXT("TEST", "Tester");
+
 public:
-    LOG_DECLARE_CLASS_CONTEXT("TEST", "Tester");
-    SoftwareContainerAgentTest() { }
+    SoftwareContainerAgentTest() {}
+
     std::shared_ptr<SoftwareContainerAgent> sca;
+
     Glib::RefPtr<Glib::MainContext> m_context = Glib::MainContext::get_default();
-    int m_preloadCount = 0;
-    bool m_shutdownContainers = true;
-    int m_shutdownTimeout = 1;
+
     std::shared_ptr<Workspace> workspace;
 
     // Define minimal required config values
@@ -83,7 +85,8 @@ public:
                                      "create-bridge = true\n"
                                      "bridge-device = lxcbr0\n"
                                      "bridge-ip = 10.0.3.1\n"
-                                     "bridge-netmask-bits = 16";
+                                     "bridge-netmask-bits = 24";
+
     const std::string valid_config = "[{\"enableWriteBuffer\": false}]";
 
     void SetUp() override


### PR DESCRIPTION
The test file for the agent component test should not have "unit test" in its name.

Also removed unused code in tests and updated values to be the same as elsewhere in the code.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>