### PR TITLE
Propagate configs from agent to SC

### DIFF
--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -115,6 +115,31 @@ public:
     }
 };
 
+
+/*
+ * Test that an agent instance can create, destroy, and create another container.
+ */
+TEST_F(SoftwareContainerAgentTest, CreateDestroyCreate) {
+    ASSERT_NO_THROW({
+        ContainerID id1 = sca->createContainer(valid_config);
+        sca->deleteContainer(id1);
+        ContainerID id2 = sca->createContainer(valid_config);
+        sca->deleteContainer(id2);
+    });
+}
+
+/*
+ * Test that an agent instance can create two containers in succession
+ */
+TEST_F(SoftwareContainerAgentTest, CreateTwice) {
+    ASSERT_NO_THROW({
+        ContainerID id1 = sca->createContainer(valid_config);
+        ContainerID id2 = sca->createContainer(valid_config);
+        sca->deleteContainer(id1);
+        sca->deleteContainer(id2);
+    });
+}
+
 TEST_F(SoftwareContainerAgentTest, CreatAndCheckContainer) {
     ASSERT_NO_THROW({
         ContainerID id = sca->createContainer(valid_config);

--- a/agent/src/softwarecontaineragent.h
+++ b/agent/src/softwarecontaineragent.h
@@ -40,10 +40,7 @@
 #include "commandjob.h"
 #include <queue>
 
-/**
- * @class softwarecontainer::SoftwareContainerAgent
- * @brief A wrapper class
- */
+
 namespace softwarecontainer {
 
 static constexpr ContainerID INVALID_CONTAINER_ID = -1;
@@ -76,6 +73,7 @@ public:
 protected:
     std::string m_message;
 };
+
 
 class SoftwareContainerAgent
 {
@@ -287,6 +285,17 @@ private:
     std::shared_ptr<DefaultConfigStore>  m_defaultConfigStore;
 
     std::shared_ptr<Config> m_config;
+
+    /*
+     * Holds all configs to use for each SoftwareContainer instance,
+     * both the static configs from Config, as well as dynamic values
+     * set by the client when creating a container.
+     *
+     * Each SoftwareContainer instance needs its own copy of these configs
+     * so this reference should be used to create a copy from, which should
+     * be passed to SoftwareContainer as a unique_ptr.
+     */
+    SoftwareContainerConfig m_containerConfig;
 };
 
 } // namespace softwarecontainer

--- a/libsoftwarecontainer/component-test/CMakeLists.txt
+++ b/libsoftwarecontainer/component-test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_definitions(-DTEST_DATA_DIR="${TEST_DATA_DIR}")
 
 include_directories(
     ${LIBSOFTWARECONTAINER_DIR}/src
+    ${LIBSOFTWARECONTAINER_DIR}/src/config
 )
 
 set(TEST_LIBRARY_DEPENDENCIES
@@ -45,6 +46,7 @@ add_gateway_test(ENABLE_NETWORKGATEWAY networkgateway_unittest.cpp)
 set(TEST_FILES
     softwarecontainer_test.cpp
     softwarecontainerlib_unittest.cpp
+    ${LIBSOFTWARECONTAINER_DIR}/src/config/softwarecontainerconfig.cpp
     ${GATEWAY_TEST_FILES}
     main.cpp
 )

--- a/libsoftwarecontainer/component-test/netlink_unittest.cpp
+++ b/libsoftwarecontainer/component-test/netlink_unittest.cpp
@@ -59,7 +59,7 @@ TEST_F(NetlinkTest, DumpOK) {
 TEST_F(NetlinkTest, LinkUpDown) {
 
     // Bring the link up (fail if it is already up)
-    auto jobLinkUp = sc->createFunctionJob([this] () {
+    auto jobLinkUp = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         // Get eth0 status
@@ -85,7 +85,7 @@ TEST_F(NetlinkTest, LinkUpDown) {
     ASSERT_TRUE(jobLinkUp->wait() == SUCCESS);
 
     // Check that the link is up
-    auto jobCheckLinkUp = sc->createFunctionJob([this] () {
+    auto jobCheckLinkUp = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         // Check that link was up
@@ -105,7 +105,7 @@ TEST_F(NetlinkTest, LinkUpDown) {
     ASSERT_TRUE(jobCheckLinkUp->wait() == SUCCESS);
 
     // Bring the link down
-    auto jobLinkDown = sc->createFunctionJob([this] () {
+    auto jobLinkDown = m_sc->createFunctionJob([this] () {
         Netlink netlink;
          // Get eth0 status
         Netlink::LinkInfo linkUp;
@@ -130,7 +130,7 @@ TEST_F(NetlinkTest, LinkUpDown) {
     ASSERT_TRUE(jobLinkDown->wait() == SUCCESS);
 
     // Check that the link is actually down
-    auto jobCheckLinkDown = sc->createFunctionJob([this] () {
+    auto jobCheckLinkDown = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         // Check that link was up
@@ -154,7 +154,7 @@ TEST_F(NetlinkTest, LinkUpDown) {
  * Make sure setting an IP address succeeds
  */
 TEST_F(NetlinkTest, SetIP) {
-    auto checkIPNotSet = sc->createFunctionJob([this] () {
+    auto checkIPNotSet = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         // Get link index
@@ -180,7 +180,7 @@ TEST_F(NetlinkTest, SetIP) {
     checkIPNotSet->start();
     ASSERT_TRUE(checkIPNotSet->wait() == SUCCESS);
 
-    auto jobSetIP = sc->createFunctionJob([this] () {
+    auto jobSetIP = m_sc->createFunctionJob([this] () {
         Netlink netlink;
         Netlink::LinkInfo link;
         if (isError(netlink.findLink(IFACE, link))) {
@@ -202,7 +202,7 @@ TEST_F(NetlinkTest, SetIP) {
     jobSetIP->start();
     ASSERT_TRUE(jobSetIP->wait() == SUCCESS);
 
-    auto checkIPSet = sc->createFunctionJob([this] () {
+    auto checkIPSet = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         // Get link index
@@ -234,7 +234,7 @@ TEST_F(NetlinkTest, SetIP) {
  */
 TEST_F(NetlinkTest, SetGatewayWithoutUp) {
     // Set the gateway
-    auto jobSetGateway = sc->createFunctionJob([this] () {
+    auto jobSetGateway = m_sc->createFunctionJob([this] () {
         Netlink netlink;
         if (isError(netlink.setDefaultGateway(GWADDR))) {
             return ERROR;
@@ -253,7 +253,7 @@ TEST_F(NetlinkTest, SetGatewayWithoutUp) {
  */
 TEST_F(NetlinkTest, SetGatewayWithUp) {
     // Bring the link up (fail if it is already up)
-    auto jobLinkUp = sc->createFunctionJob([this] () {
+    auto jobLinkUp = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         // Get eth0 status
@@ -278,7 +278,7 @@ TEST_F(NetlinkTest, SetGatewayWithUp) {
     jobLinkUp->start();
     ASSERT_TRUE(jobLinkUp->wait() == SUCCESS);
 
-    auto jobSetIP = sc->createFunctionJob([this] () {
+    auto jobSetIP = m_sc->createFunctionJob([this] () {
         Netlink netlink;
         Netlink::LinkInfo link;
         if (isError(netlink.findLink(IFACE, link))) {
@@ -301,7 +301,7 @@ TEST_F(NetlinkTest, SetGatewayWithUp) {
     ASSERT_TRUE(jobSetIP->wait() == SUCCESS);
 
     // Set the gateway
-    auto jobSetGateway = sc->createFunctionJob([this] () {
+    auto jobSetGateway = m_sc->createFunctionJob([this] () {
         Netlink netlink;
         if (isError(netlink.setDefaultGateway(GWADDR))) {
             return ERROR;
@@ -444,7 +444,7 @@ TEST_F(NetlinkTest, HasAddress) {
  * interface, and then making sure that hasAddress succeeds for each of those.
  */
 TEST_F(NetlinkTest, FindAddresses) {
-    auto jobFindAddresses = sc->createFunctionJob([this] () {
+    auto jobFindAddresses = m_sc->createFunctionJob([this] () {
         Netlink netlink;
 
         Netlink::LinkInfo link;

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
@@ -23,7 +23,7 @@
 
 void SoftwareContainerGatewayTest::givenContainerIsSet(Gateway *gw)
 {
-    sc->addGateway(gw);
+    m_sc->addGateway(gw);
 }
 
 void SoftwareContainerTest::run()
@@ -56,14 +56,23 @@ void SoftwareContainerTest::SetUp()
 
     srand(time(NULL));
     uint32_t containerId =  rand() % 100;
-    sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace, containerId));
-    sc->setMainLoopContext(m_context);
-    ASSERT_TRUE(isSuccess(sc->init()));
+
+    std::unique_ptr<SoftwareContainerConfig> config =
+        std::unique_ptr<SoftwareContainerConfig>(new SoftwareContainerConfig("10.0.3.1" /*bridge ip*/,
+                                                                             LXC_CONFIG_PATH_TESTING,
+                                                                             SHARED_MOUNTS_DIR_TESTING,
+                                                                             24 /*netmask bit length*/,
+                                                                             1 /*shutdown timeout*/));
+    config->setEnableWriteBuffer(false);
+
+    m_sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(workspace, containerId, std::move(config)));
+    m_sc->setMainLoopContext(m_context);
+    ASSERT_TRUE(isSuccess(m_sc->init()));
 }
 
 void SoftwareContainerTest::TearDown()
 {
     ::testing::Test::TearDown();
-    sc.reset();
+    m_sc.reset();
     workspace.reset();
 }

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.h
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.h
@@ -45,7 +45,7 @@ public:
 
     Glib::RefPtr<Glib::MainContext> m_context = Glib::MainContext::get_default();
     Glib::RefPtr<Glib::MainLoop> m_ml;
-    std::unique_ptr<SoftwareContainer> sc;
+    std::unique_ptr<SoftwareContainer> m_sc;
     std::shared_ptr<Workspace> workspace;
 };
 

--- a/libsoftwarecontainer/component-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainerlib_unittest.cpp
@@ -54,7 +54,7 @@ public:
 
     SoftwareContainer &getSc()
     {
-        return *sc;
+        return *m_sc;
     }
 };
 
@@ -123,8 +123,25 @@ TEST_F(SoftwareContainerApp, DoubleIDCreatesError) {
 
     const ContainerID id = 1;
 
-    SoftwareContainer s1(workspace, id);
-    SoftwareContainer s2(workspace, id);
+    std::unique_ptr<SoftwareContainerConfig> config =
+        std::unique_ptr<SoftwareContainerConfig>(new SoftwareContainerConfig("10.0.3.1" /*bridge ip*/,
+                                                                             LXC_CONFIG_PATH_TESTING,
+                                                                             SHARED_MOUNTS_DIR_TESTING,
+                                                                             24 /*netmask bit length*/,
+                                                                             1 /*shutdown timeout*/));
+    config->setEnableWriteBuffer(false);
+
+    SoftwareContainer s1(workspace, id, std::move(config));
+
+    config =
+        std::unique_ptr<SoftwareContainerConfig>(new SoftwareContainerConfig("10.0.3.1" /*bridge ip*/,
+                                                                             LXC_CONFIG_PATH_TESTING,
+                                                                             SHARED_MOUNTS_DIR_TESTING,
+                                                                             24 /*netmask bit length*/,
+                                                                             1 /*shutdown timeout*/));
+    config->setEnableWriteBuffer(false);
+
+    SoftwareContainer s2(workspace, id, std::move(config));
 
     s1.setMainLoopContext(getMainContext());
     s2.setMainLoopContext(getMainContext());
@@ -517,7 +534,16 @@ TEST(SoftwareContainer, MultithreadTest) {
     static const int TIMEOUT = 20;
 
     std::shared_ptr<Workspace> workspacePtr(new Workspace());
-    SoftwareContainer lib(workspacePtr, 2);
+
+    std::unique_ptr<SoftwareContainerConfig> config =
+        std::unique_ptr<SoftwareContainerConfig>(new SoftwareContainerConfig("10.0.3.1" /*bridge ip*/,
+                                                                             LXC_CONFIG_PATH_TESTING,
+                                                                             SHARED_MOUNTS_DIR_TESTING,
+                                                                             24 /*netmask bit length*/,
+                                                                             1 /*shutdown timeout*/));
+    config->setEnableWriteBuffer(false);
+
+    SoftwareContainer lib(workspacePtr, 2, std::move(config));
     lib.setMainLoopContext(Glib::MainContext::get_default());
 
     bool finished = false;

--- a/libsoftwarecontainer/include/config/softwarecontainerconfig.h
+++ b/libsoftwarecontainer/include/config/softwarecontainerconfig.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016-2017 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#pragma once
+
+namespace softwarecontainer {
+
+/**
+ * @class SoftwareContainerConfig
+ *
+ * @brief Contains all values that should be passed to SoftwareContainer on creation
+ *
+ * This class should be created with values that are from the static configs, i.e. the
+ * configs that are known and fetched through Config (usually by SoftwareContainerAgent)
+ * during startup.
+ *
+ * This class is also used to carry dynamic configs to SoftwareContainer and these can
+ * be set through setters on this class. However, this class is not intended to be used
+ * to set values dynamically in any way by SoftwareContainer, so it should be received
+ * as const.
+ */
+class SoftwareContainerConfig
+{
+public:
+    SoftwareContainerConfig() {}
+
+    SoftwareContainerConfig(const std::string &bridgeIp,
+                            const std::string &containerConfigPath,
+                            const std::string &containerRootDir,
+                            int netmaskBitLength,
+                            unsigned int containerShutdownTimeout);
+
+    ~SoftwareContainerConfig() {}
+
+    /*
+     * Setters for the values that are not part of the static configs
+     */
+    void setEnableWriteBuffer(bool enabledFlag);
+
+    /*
+     * Getters for values that are set on creation only, i.e. these originate from the
+     * static configs and should not be "re-set" after creation of this class.
+     */
+    std::string bridgeIp() const;
+    std::string containerConfigPath() const;
+    std::string containerRootDir() const;
+    int netmaskBitLength() const;
+    unsigned int containerShutdownTimeout() const;
+
+    /*
+     * Getters for values that do not originate from the static configs and thus might be
+     * set after creation of this class, i.e. these can be set with setters
+     */
+    bool enableWriteBuffer() const;
+
+private:
+    std::string m_bridgeIp;
+    std::string m_containerConfigPath;
+    std::string m_containerRootDir;
+    int m_netmaskBitLength;
+    unsigned int m_containerShutdownTimeout;
+
+    bool m_enableWriteBuffer;
+};
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -24,6 +24,7 @@
 #include "workspace.h"
 #include "gatewayconfig.h"
 #include "signalconnectionshandler.h"
+#include "config/softwarecontainerconfig.h"
 
 #include <glibmm.h>
 
@@ -50,8 +51,7 @@ public:
 
     SoftwareContainer(std::shared_ptr<Workspace> workspace,
                       const ContainerID id,
-                      std::string bridgeIp = "10.0.3.1",
-                      int netmaskBits = 16);
+                      std::unique_ptr<const SoftwareContainerConfig> config);
 
     ~SoftwareContainer();
 

--- a/libsoftwarecontainer/src/CMakeLists.txt
+++ b/libsoftwarecontainer/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(softwarecontainer SHARED
     container.cpp
     softwarecontainer.cpp
     workspace.cpp
+    config/softwarecontainerconfig.cpp
     ${GATEWAY_SOURCES}
     ${JOB_SOURCES}
 )

--- a/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
+++ b/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016-2017 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include <string>
+
+#include "config/softwarecontainerconfig.h"
+
+
+namespace softwarecontainer {
+
+SoftwareContainerConfig::SoftwareContainerConfig(const std::string &bridgeIp,
+                                                 const std::string &containerConfigPath,
+                                                 const std::string &containerRootDir,
+                                                 int netmaskBitLength,
+                                                 unsigned int containerShutdownTimeout):
+    m_bridgeIp(bridgeIp),
+    m_containerConfigPath(containerConfigPath),
+    m_containerRootDir(containerRootDir),
+    m_netmaskBitLength(netmaskBitLength),
+    m_containerShutdownTimeout(containerShutdownTimeout)
+{
+}
+
+void SoftwareContainerConfig::setEnableWriteBuffer(bool enabledFlag)
+{
+    m_enableWriteBuffer = enabledFlag;
+}
+
+std::string SoftwareContainerConfig::bridgeIp() const
+{
+    return m_bridgeIp;
+}
+
+std::string SoftwareContainerConfig::containerConfigPath() const
+{
+    return m_containerConfigPath;
+}
+
+std::string SoftwareContainerConfig::containerRootDir() const
+{
+    return m_containerRootDir;
+}
+
+int SoftwareContainerConfig::netmaskBitLength() const
+{
+    return m_netmaskBitLength;
+}
+
+unsigned int SoftwareContainerConfig::containerShutdownTimeout() const
+{
+    return m_containerShutdownTimeout;
+}
+
+bool SoftwareContainerConfig::enableWriteBuffer() const
+{
+    return m_enableWriteBuffer;
+}
+
+
+} // namespace softwarecontainer

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -58,18 +58,20 @@ namespace softwarecontainer {
 
 SoftwareContainer::SoftwareContainer(std::shared_ptr<Workspace> workspace,
                                      const ContainerID id,
-                                     std::string bridgeIp,
-                                     int netmaskBits) :
+                                     std::unique_ptr<const SoftwareContainerConfig> config):
     m_workspace(workspace),
-    m_containerID(id),
-    m_bridgeIp(bridgeIp),
-    m_netmaskBits(netmaskBits),
-    m_container(new Container("SC-" + std::to_string(id),
-                              m_workspace->m_containerConfigPath,
-                              m_workspace->m_containerRootDir,
-                              m_workspace->m_enableWriteBuffer,
-                              m_workspace->m_containerShutdownTimeout))
+    m_containerID(id)
 {
+    m_bridgeIp = config->bridgeIp();
+    m_netmaskBits = config->netmaskBitLength();
+
+    m_container = std::shared_ptr<ContainerAbstractInterface>(
+        new Container("SC-" + std::to_string(id),
+                      config->containerConfigPath(),
+                      config->containerRootDir(),
+                      config->enableWriteBuffer(),
+                      config->containerShutdownTimeout()));
+
     m_containerState = ContainerState::CREATED;
 }
 


### PR DESCRIPTION
SoftwareContainer now takes configs from the agent on creation.
The agent handles the static and dynamic configs and pass them
all to SC together.

This is a step towards removing the Workspace as well.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>