### PR TITLE
Cleanup in SC and SCA

### DIFF
--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -175,7 +175,6 @@ ContainerID SoftwareContainerAgent::createContainer(const std::string &config)
     m_containerConfig.setEnableWriteBuffer(options.enableWriteBuffer);
 
     std::pair<ContainerID, SoftwareContainerPtr> pair = std::move(getContainerPair());
-    pair.second->setMainLoopContext(m_mainLoopContext);
 
     ContainerID containerID = pair.first;
 

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
@@ -72,7 +72,6 @@ void SoftwareContainerTest::SetUp()
     uint32_t containerId =  rand() % 100;
 
     m_sc = std::unique_ptr<SoftwareContainer>(new SoftwareContainer(containerId, std::move(config)));
-    m_sc->setMainLoopContext(m_context);
     ASSERT_TRUE(isSuccess(m_sc->init()));
 }
 

--- a/libsoftwarecontainer/component-test/softwarecontainerlib_unittest.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainerlib_unittest.cpp
@@ -116,9 +116,6 @@ TEST_F(SoftwareContainerApp, DoubleIDCreatesError) {
     config = createConfig();
     SoftwareContainer s2(id, std::move(config));
 
-    s1.setMainLoopContext(getMainContext());
-    s2.setMainLoopContext(getMainContext());
-
     ASSERT_TRUE(isSuccess(s1.init()));
     ASSERT_TRUE(isError(s2.init()));
 }
@@ -509,7 +506,6 @@ TEST_F(SoftwareContainerApp, MultithreadTest) {
 
     auto config = createConfig();
     SoftwareContainer lib(containerID, std::move(config));
-    lib.setMainLoopContext(Glib::MainContext::get_default());
 
     bool finished = false;
 

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -63,11 +63,6 @@ public:
     ~SoftwareContainer();
 
     /**
-     * @brief Set the main loop
-     */
-    void setMainLoopContext(Glib::RefPtr<Glib::MainContext> mainLoopContext);
-
-    /**
      * @brief Shutdown the container
      */
     ReturnCode shutdown();
@@ -97,8 +92,6 @@ public:
 
     bool isInitialized() const;
 
-    ReturnCode start();
-
     ReturnCode init();
 
     std::shared_ptr<ContainerAbstractInterface> getContainer();
@@ -122,6 +115,8 @@ public:
     ReturnCode startGateways(const GatewayConfiguration &configs);
 
 private:
+    ReturnCode start();
+
     ReturnCode configureGateways(const GatewayConfiguration &gwConfig);
     ReturnCode activateGateways();
     ReturnCode shutdownGateways();

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -79,11 +79,6 @@ SoftwareContainer::~SoftwareContainer()
 {
 }
 
-void SoftwareContainer::setMainLoopContext(Glib::RefPtr<Glib::MainContext> mainLoopContext)
-{
-    m_mainLoopContext = mainLoopContext;
-}
-
 ReturnCode SoftwareContainer::start()
 {
     log_debug() << "Initializing container";
@@ -111,11 +106,6 @@ ReturnCode SoftwareContainer::start()
 
 ReturnCode SoftwareContainer::init()
 {
-    if (m_mainLoopContext->gobj() == nullptr) {
-        log_error() << "Main loop context must be set first !";
-        return ReturnCode::FAILURE;
-    }
-
     if (getContainerState() != ContainerState::INITIALIZED) {
         if (isError(start())) {
             log_error() << "Failed to start container";


### PR DESCRIPTION
Removed mainloop context related code from SC,
and moved a method from public to private scope in SC.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>