### PR TITLE
Use Glib::build_filename() for combining paths

### DIFF
--- a/agent/src/capability/baseconfigstore.cpp
+++ b/agent/src/capability/baseconfigstore.cpp
@@ -39,10 +39,6 @@ BaseConfigStore::BaseConfigStore(const std::string &inputPath)
     }
 }
 
-BaseConfigStore::~BaseConfigStore()
-{
-}
-
 void BaseConfigStore::readCapsFromDir(const std::string &dirPath)
 {
     std::string errorMessage;
@@ -65,7 +61,7 @@ void BaseConfigStore::readCapsFromDir(const std::string &dirPath)
     }
 
     for (std::string file : files) {
-        std::string filePath = dirPath + file;
+        std::string filePath = buildPath(dirPath, file);
 
         readCapsFromFile(filePath);
     }

--- a/agent/src/capability/baseconfigstore.h
+++ b/agent/src/capability/baseconfigstore.h
@@ -23,11 +23,13 @@
  */
 
 #pragma once
+
 #include "softwarecontainer-common.h"
 #include "gatewayconfig.h"
 #include "configstoreerror.h"
 
 #include <jsonparser.h>
+
 
 namespace softwarecontainer {
 
@@ -45,11 +47,9 @@ public:
      * or if the path is not allowed
      * @throws ServiceManifestParseError if parsing of the json file(s) fails
      * @throws CapabilityParseError if parsing of one or more Capabilities or Gateway
-     * Configurations in a file is unsuccessful
+     *         Configurations in a file is unsuccessful
      */
     BaseConfigStore(const std::string &filePath);
-
-    virtual ~BaseConfigStore();
 
 protected:
     std::map<std::string, GatewayConfiguration> m_capMap;

--- a/agent/src/capability/filteredconfigstore.cpp
+++ b/agent/src/capability/filteredconfigstore.cpp
@@ -25,10 +25,6 @@ FilteredConfigStore::FilteredConfigStore(const std::string &path): BaseConfigSto
 {
 }
 
-FilteredConfigStore::~FilteredConfigStore()
-{
-}
-
 const std::vector<std::string> FilteredConfigStore::IDs() const
 {
     std::vector<std::string> ids;

--- a/agent/src/capability/filteredconfigstore.h
+++ b/agent/src/capability/filteredconfigstore.h
@@ -27,7 +27,6 @@ class FilteredConfigStore : public BaseConfigStore
     LOG_DECLARE_CLASS_CONTEXT("FCS", "FilteredConfigStore");
 public:
     FilteredConfigStore(const std::string &path);
-    ~FilteredConfigStore();
 
     /**
      * @brief Returns all capability IDs

--- a/common/recursivecopy.cpp
+++ b/common/recursivecopy.cpp
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <string>
 
+#include <glibmm.h>
+
 namespace softwarecontainer {
 
 std::string dstRoot;
@@ -50,9 +52,9 @@ int copyFile(const char* srcPath, const struct stat* sb, int typeflag)
     std::string src(srcPath);
 
     if (src.find(srcRoot) != std::string::npos) {
-        dstPath = dstRoot + src.erase(0, srcRoot.length());
+        dstPath = buildPath(dstRoot, src.erase(0, srcRoot.length()));
     } else {
-        dstPath = dstRoot + src;
+        dstPath = buildPath(dstRoot, src);
     }
 
     switch(typeflag) {
@@ -88,8 +90,7 @@ ReturnCode RecursiveCopy::copy(std::string src, std::string dst)
     return retval;
 }
 
-RecursiveCopy::RecursiveCopy() { }
-
-RecursiveCopy::~RecursiveCopy() { }
+RecursiveCopy::RecursiveCopy() {}
+RecursiveCopy::~RecursiveCopy() {}
 
 } // namespace softwarecontainer

--- a/common/softwarecontainer-common.cpp
+++ b/common/softwarecontainer-common.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <cstdarg>
 
 #include <unistd.h>
 #include <sys/stat.h>
@@ -108,6 +109,16 @@ std::string parentPath(const std::string &path_)
     }
     std::string parentPath = path.substr(0, pos - strlen(separator) + 1);
     return parentPath;
+}
+
+std::string buildPath(const std::string &arg1, const std::string &arg2)
+{
+    return Glib::build_filename(arg1, arg2);
+}
+
+std::string buildPath(const std::string &arg1, const std::string &arg2, const std::string &arg3)
+{
+    return buildPath(buildPath(arg1, arg2), arg3);
 }
 
 ReturnCode touch(const std::string &path)

--- a/common/softwarecontainer-common.h
+++ b/common/softwarecontainer-common.h
@@ -146,4 +146,14 @@ ReturnCode writeToFile(const std::string &path, const std::string &content);
 ReturnCode readFromFile(const std::string &path, std::string &content);
 bool parseInt(const char *args, int *result);
 
+/*
+ * This builds a full path from parts, including the appropriate separator.
+ *
+ * Example: buildPath("usr", "local", "bin) => usr/local/bin
+ *
+ * @returns a string representing the combined path
+ */
+std::string buildPath(const std::string &arg1, const std::string &arg2);
+std::string buildPath(const std::string &arg1, const std::string &arg2, const std::string &arg3);
+
 } // namespace softwarecontainer;

--- a/common/unit-test/recursivecopy_unittest.cpp
+++ b/common/unit-test/recursivecopy_unittest.cpp
@@ -42,8 +42,6 @@ public:
     FileToolkitWithUndo ft;
     std::string srcdir;
     std::string dstdir;
-
-
 };
 
 void createFile(std::string dst, std::string val="abcdefg123")
@@ -73,45 +71,67 @@ TEST_F(RecursiveCopyTest, copyDirEmptyToEmpty)
 
 TEST_F(RecursiveCopyTest, copyDirFilesToEmpty)
 {
-    createFile(srcdir + "/lala.txt");
+    std::string srcFile = buildPath(srcdir, "lala.txt");
+    std::string dstFile = buildPath(dstdir, "lala.txt");
+    createFile(srcFile);
+
     ASSERT_TRUE(RecursiveCopy::getInstance().copy(srcdir, dstdir) == ReturnCode::SUCCESS);
-    ASSERT_TRUE(isFile(srcdir + "/lala.txt"));
-    ASSERT_TRUE(isFile(dstdir + "/lala.txt"));
+    ASSERT_TRUE(isFile(srcFile));
+    ASSERT_TRUE(isFile(dstFile));
 }
 
 TEST_F(RecursiveCopyTest, copyDirEmptyToFiles)
 {
-    createFile(dstdir + "/lala.txt");
+    std::string dstFile = buildPath(dstdir, "lala.txt");
+    std::string srcFile = buildPath(srcdir, "lala.txt");
+    createFile(dstFile);
+
     ASSERT_TRUE(RecursiveCopy::getInstance().copy(srcdir, dstdir) == ReturnCode::SUCCESS);
-    ASSERT_FALSE(isFile(srcdir + "/lala.txt"));
-    ASSERT_TRUE(isFile(dstdir + "/lala.txt"));
+    ASSERT_FALSE(isFile(srcFile));
+    ASSERT_TRUE(isFile(dstFile));
     ASSERT_TRUE(isDirectoryEmpty(srcdir));
 }
 
 TEST_F(RecursiveCopyTest, copyDirFilesToFiles)
 {
-    createFile(srcdir + "/lala.txt");
-    createFile(dstdir + "/lala2.txt");
-    ASSERT_FALSE(isFile(srcdir + "/lala2.txt"));
+    std::string srcFile = buildPath(srcdir, "lala.txt");
+    std::string srcFile2 = buildPath(srcdir, "lala2.txt");
+    std::string dstFile = buildPath(dstdir, "lala.txt");
+    std::string dstFile2 = buildPath(dstdir, "lala2.txt");
+    createFile(srcFile);
+    createFile(dstFile2);
+
+    ASSERT_FALSE(isFile(srcFile2));
+
     ASSERT_TRUE(RecursiveCopy::getInstance().copy(srcdir, dstdir) == ReturnCode::SUCCESS);
-    ASSERT_TRUE(isFile(srcdir + "/lala.txt"));
-    ASSERT_FALSE(isFile(srcdir + "/lala2.txt"));
-    ASSERT_TRUE(isFile(dstdir + "/lala.txt"));
-    ASSERT_TRUE(isFile(dstdir + "/lala2.txt"));
+
+    ASSERT_TRUE(isFile(srcFile));
+    ASSERT_FALSE(isFile(srcFile2));
+
+    ASSERT_TRUE(isFile(dstFile));
+    ASSERT_TRUE(isFile(dstFile2));
 }
 
 TEST_F(RecursiveCopyTest, copyDirFilesToFilesOverWrite)
 {
     std::string content1 = "abcdefg123";
     std::string content2 = "123gfedcba";
-    createFile(srcdir + "/lala.txt", content1);
-    createFile(dstdir + "/lala.txt", content2);
-    ASSERT_TRUE(checkContent(srcdir + "/lala.txt", content1));
-    ASSERT_TRUE(checkContent(dstdir + "/lala.txt", content2));
+
+    std::string srcFile = buildPath(srcdir, "lala.txt");
+    std::string dstFile = buildPath(dstdir, "lala.txt");
+
+    createFile(srcFile, content1);
+    createFile(dstFile, content2);
+
+    ASSERT_TRUE(checkContent(srcFile, content1));
+    ASSERT_TRUE(checkContent(dstFile, content2));
+
     ASSERT_TRUE(RecursiveCopy::getInstance().copy(srcdir, dstdir) == ReturnCode::SUCCESS);
-    ASSERT_TRUE(isFile(srcdir + "/lala.txt"));
-    ASSERT_TRUE(isFile(dstdir + "/lala.txt"));
-    ASSERT_TRUE(checkContent(srcdir + "/lala.txt", content1));
-    ASSERT_TRUE(checkContent(dstdir + "/lala.txt", content1));
+
+    ASSERT_TRUE(isFile(srcFile));
+    ASSERT_TRUE(isFile(dstFile));
+
+    ASSERT_TRUE(checkContent(srcFile, content1));
+    ASSERT_TRUE(checkContent(dstFile, content1));
 }
 

--- a/libsoftwarecontainer/component-test/softwarecontainerlib_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainerlib_componenttest.cpp
@@ -87,8 +87,7 @@ TEST_F(SoftwareContainerApp, TestWaylandWhitelist) {
             return ERROR;
         }
         log_debug() << "Wayland dir : " << waylandDir;
-        std::string socketPath = logging::StringBuilder() << waylandDir << "/"
-                                                          << WaylandGateway::SOCKET_FILE_NAME;
+        std::string socketPath = buildPath(waylandDir, WaylandGateway::SOCKET_FILE_NAME);
         log_debug() << "isSocket : " << socketPath << " " << isSocket(socketPath);
         if ( !isSocket(socketPath) ) {
             return ERROR;
@@ -388,6 +387,7 @@ TEST_F(SoftwareContainerApp, TestUnixSocket) {
 
     char *tmp = new char[strlen(tempDirname) + 8];
     strcpy(tmp, tempDirname);
+
     char *tempUnixSocket = strcat(tmp, "/socket");
 
     auto job1 = getSc().createFunctionJob([&] () {
@@ -507,7 +507,7 @@ TEST_F(SoftwareContainerApp, DISABLED_TestPulseAudioEnabled) {
     startGateways(configStr, PulseGateway::ID);
 
     // We need access to the test file, so we bind mount it
-    std::string soundFile = std::string(TEST_DATA_DIR) + std::string("/Rear_Center.wav");
+    std::string soundFile = buildPath(TEST_DATA_DIR, std::string("Rear_Center.wav"));
     ASSERT_TRUE(isSuccess(bindMountInContainer(soundFile, soundFile, true)));
 
     // Make sure the file is there

--- a/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
+++ b/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
@@ -47,9 +47,6 @@ SoftwareContainerConfig::SoftwareContainerConfig(
     m_containerRootDir(containerRootDir),
     m_containerShutdownTimeout(containerShutdownTimeout)
 {
-    if (m_containerRootDir.back() != '/') {
-        m_containerRootDir += "/";
-    }
 }
 
 void SoftwareContainerConfig::setEnableWriteBuffer(bool enabledFlag)

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.cpp
@@ -28,10 +28,8 @@ DBusGatewayInstance::DBusGatewayInstance(ProxyType type
     : Gateway(ID)
     , m_type(type)
 {
-    m_socket = gatewayDir
-             + (m_type == SessionProxy ? "/sess_" : "/sys_")
-             + name
-             + ".sock";
+    std::string socketName = (m_type == SessionProxy ? "sess_" : "sys_") + name + ".sock";
+    m_socket = buildPath(gatewayDir, socketName);
 
     // Write configuration
     m_entireConfig = json_object();
@@ -81,7 +79,7 @@ bool DBusGatewayInstance::activateGateway()
     std::string variable = std::string("DBUS_")
                          + (m_type == SessionProxy ? "SESSION" : "SYSTEM")
                          + std::string("_BUS_ADDRESS");
-    std::string value = "unix:path=/gateways/" + socketName();
+    std::string value = "unix:path=" + buildPath("/gateways", socketName());
     setEnvironmentVariable(variable, value);
 
     std::vector<std::string> commandVec = { "dbus-proxy"
@@ -221,9 +219,7 @@ bool DBusGatewayInstance::teardownGateway()
 
 std::string DBusGatewayInstance::socketName()
 {
-    // Return the filename after stripping directory info
-    std::string socket(m_socket.c_str());
-    return socket.substr(socket.rfind('/') + 1);
+    return basename(m_socket.c_str());
 }
 
 } // namespace softwarecontainer

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.cpp
@@ -66,8 +66,8 @@ ReturnCode DeviceNodeGateway::applySettings()
     for (auto &dev : devlist) {
         log_info() << "Mapping device " << dev.name;
 
-        std::string devicePathInContainerOnHost = getContainer()->rootFS() + dev.name;
-        std::string deviceParent = dirname(strdup(devicePathInContainerOnHost.c_str()));
+        std::string devicePathInContainerOnHost = buildPath(getContainer()->rootFS(), dev.name);
+        std::string deviceParent = parentPath(devicePathInContainerOnHost);
 
         // Already existing files can't be converted into directories
         if (existsInFileSystem(deviceParent) && !isDirectory(deviceParent)) {

--- a/libsoftwarecontainer/src/gateway/pulsegateway.cpp
+++ b/libsoftwarecontainer/src/gateway/pulsegateway.cpp
@@ -57,8 +57,8 @@ ReturnCode PulseGateway::enablePulseAudio() {
         return ReturnCode::FAILURE;
     }
 
-    log_info() << "enabling pulseaudio gateway. Socket location : " << dir;
-    std::string pathInContainer = "/gateways/" + std::string(SOCKET_FILE_NAME);
+    log_info() << "Enabling pulseaudio gateway. Socket location : " << dir;
+    std::string pathInContainer = buildPath("/gateways/", SOCKET_FILE_NAME);
     ReturnCode result = getContainer()->bindMountInContainer(std::string(dir),
                                                              pathInContainer,
                                                              false);

--- a/libsoftwarecontainer/src/gateway/waylandgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.cpp
@@ -70,8 +70,8 @@ bool WaylandGateway::activateGateway()
     }
 
     log_info() << "enabling Wayland gateway. Socket dir:" << dir;
-    std::string pathInHost = logging::StringBuilder() << dir << "/" << SOCKET_FILE_NAME;
-    std::string pathInContainer = logging::StringBuilder() << "/gateways/" << SOCKET_FILE_NAME;
+    std::string pathInHost = buildPath(dir, SOCKET_FILE_NAME);
+    std::string pathInContainer = buildPath("/gateways", SOCKET_FILE_NAME);
     ReturnCode result = getContainer()->bindMountInContainer(pathInHost, pathInContainer, false);
 
     if (isError(result)) {
@@ -80,7 +80,6 @@ bool WaylandGateway::activateGateway()
     }
 
     setEnvironmentVariable(WAYLAND_RUNTIME_DIR_VARIABLE_NAME, parentPath(pathInContainer));
-
     return true;
 }
 

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -190,10 +190,7 @@ ReturnCode SoftwareContainer::configureGateways(const GatewayConfiguration &gwCo
         json_t *config = gwConfig.config(gatewayId);
         if (config != nullptr) {
             std::string configStr = json_dumps(config,0);
-            log_debug() << "Configuring gateway \""
-                        << gatewayId
-                        << "\" with config: "
-                        << configStr;
+            log_debug() << "Configuring gateway \"" << gatewayId << "\" with config: " << configStr;
             try {
                 ReturnCode configurationResult = gateway->setConfig(configStr);
                 if (isError(configurationResult)) {
@@ -206,9 +203,7 @@ ReturnCode SoftwareContainer::configureGateways(const GatewayConfiguration &gwCo
                  * as it means one or more capabilities are broken.
                  */
                 log_error() << "Fatal error when configuring gateway \""
-                            << gatewayId
-                            << "\" : "
-                            << error.what();
+                            << gatewayId << "\" : " << error.what();
                 throw error;
             }
             json_decref(config);
@@ -227,9 +222,7 @@ ReturnCode SoftwareContainer::activateGateways()
             if (gateway->isConfigured()) {
                 ReturnCode activationResult = gateway->activate();
                 if (isError(activationResult)) {
-                    log_error() << "Failed to activate gateway \""
-                                << gatewayId
-                                << "\"";
+                    log_error() << "Failed to activate gateway \"" << gatewayId << "\"";
                     return activationResult;
                 }
             }
@@ -240,9 +233,7 @@ ReturnCode SoftwareContainer::activateGateways()
              * capabilities implies, i.e. the application environment will be in a broken state.
              */
             log_error() << "Fatal error when activating gateway \""
-                        << gatewayId
-                        << "\" : "
-                        << error.what();
+                        << gatewayId << "\" : " << error.what();
             throw error;
         }
     }
@@ -257,7 +248,7 @@ ReturnCode SoftwareContainer::shutdown()
 
 ReturnCode SoftwareContainer::shutdown(unsigned int timeout)
 {
-    log_debug() << "shutdown called"; // << logging::getStackTrace();
+    log_debug() << "Shutdown called";
     if(isError(shutdownGateways())) {
         log_error() << "Could not shut down all gateways cleanly, check the log";
     }
@@ -307,12 +298,12 @@ std::shared_ptr<ContainerAbstractInterface> SoftwareContainer::getContainer()
 std::string SoftwareContainer::getContainerDir()
 {
     const std::string containerID = std::string(m_container->id());
-    return m_config->containerRootDir() + "/" + containerID;
+    return buildPath(m_config->containerRootDir(), containerID);
 }
 
 std::string SoftwareContainer::getGatewayDir()
 {
-    return getContainerDir() + "/gateways";
+    return buildPath(getContainerDir(), "gateways");
 }
 
 ObservableProperty<ContainerState> &SoftwareContainer::getContainerState()
@@ -354,7 +345,7 @@ void SoftwareContainer::checkWorkspace()
 void SoftwareContainer::checkNetworkSettings()
 {
     std::vector<std::string> argv;
-    argv.push_back(std::string(INSTALL_BINDIR) + "/setup_softwarecontainer.sh");
+    argv.push_back(buildPath(std::string(INSTALL_BINDIR), "setup_softwarecontainer.sh"));
     argv.push_back(m_config->bridgeDevice());
 
     if (m_config->shouldCreateBridge()) {


### PR DESCRIPTION
This is less error-prone and ensures we avoid both missing
slashes and double slashes in path names.

Also some general minor cleanups of things that I came across while doing this.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>