### PR TITLE
Added new states for SoftwareContainer class

### DIFF
--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -169,78 +169,64 @@ TEST_F(SoftwareContainerAgentTest, CreateContainerWithConf) {
 }
  */
 
-// Freeze an invalid container
-TEST_F(SoftwareContainerAgentTest, FreezeInvalidContainer) {
+// Suspending an invalid container should throw an exception
+TEST_F(SoftwareContainerAgentTest, SuspendInvalidContainer) {
     ASSERT_THROW(sca->suspendContainer(0), SoftwareContainerError);
 }
 
-// Thaw an invalid container
-TEST_F(SoftwareContainerAgentTest, ThawInvalidContainer) {
+// Resuming an invalid container should throw an exception
+TEST_F(SoftwareContainerAgentTest, ResumeInvalidContainer) {
     ASSERT_THROW(sca->resumeContainer(0), SoftwareContainerError);
 }
 
-// Thaw a container that has not been frozen
-TEST_F(SoftwareContainerAgentTest, ThawUnfrozenContainer) {
-    ASSERT_NO_THROW({
+// Resuming a container that has not been suspended should throw an exception
+TEST_F(SoftwareContainerAgentTest, ResumeNonSuspendedContainer) {
+    ASSERT_THROW({
         ContainerID id = sca->createContainer(valid_config);
 
         sca->getContainer(id);
         sca->resumeContainer(id);
-    });
+    }, InvalidOperationError);
 }
 
-// Freeze a container and try to resume it twice
-TEST_F(SoftwareContainerAgentTest, FreezeContainerAndThawTwice) {
-    ASSERT_NO_THROW({
+// Suspending a container and trying to resume it twice should throw
+// an exception
+TEST_F(SoftwareContainerAgentTest, SuspendContainerAndResumeTwice) {
+    ASSERT_THROW({
         ContainerID id = sca->createContainer(valid_config);
         sca->getContainer(id);
 
         sca->suspendContainer(id);
         sca->resumeContainer(id);
         sca->resumeContainer(id);
-    });
+    }, InvalidOperationError);
 }
 
-// Freeze an already frozen container
-TEST_F(SoftwareContainerAgentTest, FreezeFrozenContainer) {
-    ASSERT_NO_THROW({
-        ContainerID id = sca->createContainer(valid_config);
-        sca->getContainer(id);
-
-        sca->suspendContainer(id);
-        sca->suspendContainer(id);
-    });
-}
-
-// Freeze an already frozen container, and then resume it
-TEST_F(SoftwareContainerAgentTest, DoubleFreezeContainerAndThaw) {
-    ASSERT_NO_THROW({
+// Suspending an already suspended container should throw an exception
+TEST_F(SoftwareContainerAgentTest, SuspendSuspendedContainer) {
+    ASSERT_THROW({
         ContainerID id = sca->createContainer(valid_config);
         sca->getContainer(id);
 
         sca->suspendContainer(id);
         sca->suspendContainer(id);
-
-        sca->resumeContainer(id);
-    });
+    }, InvalidOperationError);
 }
 
-// Double suspend and then double resume
-TEST_F(SoftwareContainerAgentTest, DoubleFreezeAndDoubleThawContainer) {
+// Suspend and resume a container shold not throw an exception
+TEST_F(SoftwareContainerAgentTest, DoubleSuspendContainerAndResume) {
     ASSERT_NO_THROW({
         ContainerID id = sca->createContainer(valid_config);
         sca->getContainer(id);
 
         sca->suspendContainer(id);
-        sca->suspendContainer(id);
 
-        sca->resumeContainer(id);
         sca->resumeContainer(id);
     });
 }
 
-// Make sure you can still shutdown a frozen container
-TEST_F(SoftwareContainerAgentTest, ShutdownFrozenContainer) {
+// Make sure you can still shut down a suspended container
+TEST_F(SoftwareContainerAgentTest, ShutdownSuspendedContainer) {
     ASSERT_NO_THROW({
         ContainerID id = sca->createContainer(valid_config);
         sca->getContainer(id);

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -184,14 +184,13 @@ pid_t SoftwareContainerAgent::execute(ContainerID containerID,
     SoftwareContainerPtr container = getContainer(containerID);
 
     /*
-     * We want to always apply any default capabilities we have. If the container is in READY state,
-     * that means that its gateways have been configured. The only way to configure the gateways
-     * from the agent is through setCapabilities - which sets the default caps also.
+     * We want to always apply any default capabilities we have. The only way to configure
+     * the gateways from the agent is through setCapabilities - which sets the default caps also.
      *
-     * If it has not been set, then we use a call without arguments to setCapabilities to set it up,
-     * since we then should get only the default ones.
+     * If it has not been set previously, then we use a call without arguments to setCapabilities
+     * to set it up, since we then should get only the default ones.
      */
-    if (container->getContainerState() != ContainerState::READY) {
+    if (!m_containers[containerID]->previouslyConfigured()) {
         log_info() << "Container not configured yet, configuring with default capabilities, if any";
         GatewayConfiguration gatewayConfigs = m_defaultConfigStore->configs();
         if (!updateGatewayConfigs(containerID, gatewayConfigs)) {
@@ -199,6 +198,7 @@ pid_t SoftwareContainerAgent::execute(ContainerID containerID,
             log_error() << errorMessage;
             throw SoftwareContainerError(errorMessage);
         }
+
     }
 
     // Set up a CommandJob for this run in the container

--- a/common/softwarecontainer-common.h
+++ b/common/softwarecontainer-common.h
@@ -35,13 +35,6 @@ static constexpr pid_t INVALID_PID = -1;
 static constexpr int INVALID_FD = -1;
 static constexpr uid_t ROOT_UID = 0;
 
-enum class ContainerState
-{
-    CREATED,
-    INITIALIZED,
-    READY,
-    TERMINATED
-};
 
 /**
  * @brief The ReturnCode enum contains common return values.


### PR DESCRIPTION
SC now throws exceptions if an operation is made when SC
is in an inappropriate state. Failures in the Container
class now results in exceptions as well.

All methods on the SC interface are not updated fully to
use the new states and exceptions yet.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>