### PR TITLE
Gateway::setConfig now takes a json_t as input

### DIFF
--- a/libsoftwarecontainer/component-test/cgroupsgateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/cgroupsgateway_componenttest.cpp
@@ -46,7 +46,8 @@ TEST_F(CgroupsGatewayTest, ActivateWithValidConf) {
                                     \"setting\": \"memory.limit_in_bytes\",\
                                     \"value\": \"2000000\"\
                                 }]";
+    loadConfig(config);
 
-    ASSERT_TRUE(isSuccess(gw->setConfig(config)));
+    ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
     ASSERT_TRUE(isSuccess(gw->activate()));
 }

--- a/libsoftwarecontainer/component-test/dbusgateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/dbusgateway_componenttest.cpp
@@ -65,7 +65,9 @@ public:
             EXPECT_CALL(*gw, testDBusConnection(_));
         }
 
-        ASSERT_TRUE(isSuccess(gw->setConfig(config)));
+        loadConfig(config);
+
+        ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
         ASSERT_TRUE(isSuccess(gw->activate()));
     }
 };

--- a/libsoftwarecontainer/component-test/devicenodegateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/devicenodegateway_componenttest.cpp
@@ -66,7 +66,8 @@ TEST_F(DeviceNodeGatewayTest, TestActivateWithValidConf) {
                                   }\
                                 ]";
 
-    ASSERT_TRUE(isSuccess(gw->setConfig(config)));
+    loadConfig(config);
+    ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
     ASSERT_TRUE(isSuccess(gw->activate()));
 }
 
@@ -85,7 +86,8 @@ TEST_F(DeviceNodeGatewayTest, TestOverwriteDeviceFails) {
                                   }\
                                 ]";
 
-    ASSERT_TRUE(isSuccess(gw->setConfig(config)));
+    loadConfig(config);
+    ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
     ASSERT_FALSE(isSuccess(gw->activate()));
 
 }

--- a/libsoftwarecontainer/component-test/filegateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/filegateway_componenttest.cpp
@@ -65,6 +65,7 @@ TEST_F(FileGatewayTest, TestActivateWithMinimalValidConf) {
             ", \"path-container\" : \"" + CONTAINER_PATH + "\""
         "}"
     "]";
-    ASSERT_TRUE(isSuccess(gw->setConfig(config)));
+    loadConfig(config);
+    ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
     ASSERT_TRUE(isSuccess(gw->activate()));
 }

--- a/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
@@ -75,7 +75,8 @@ protected:
  */
 TEST_F(NetworkGatewayTest, Activate) {
     givenContainerIsSet(gw);
-    ASSERT_TRUE(isSuccess(gw->setConfig(VALID_FULL_CONFIG)));
+    loadConfig(VALID_FULL_CONFIG);
+    ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
     ASSERT_TRUE(isSuccess(gw->activate()));
 }
 
@@ -86,8 +87,9 @@ TEST_F(NetworkGatewayTest, Activate) {
 TEST_F(NetworkGatewayTest, ActivateBadConfig) {
     givenContainerIsSet(gw);
     const std::string config = "[{\"internet-access\": true}]";
+    loadConfig(config);
 
-    ASSERT_TRUE(isError(gw->setConfig(config)));
+    ASSERT_TRUE(isError(gw->setConfig(jsonConfig)));
     ASSERT_THROW(gw->activate(), GatewayError);
 }
 
@@ -101,6 +103,7 @@ TEST_F(NetworkGatewayTest, ActivateNoBridge) {
     ::testing::DefaultValue<ReturnCode>::Set(ReturnCode::FAILURE);
         EXPECT_CALL(*gw, isBridgeAvailable());
 
-    ASSERT_TRUE(isSuccess(gw->setConfig(VALID_FULL_CONFIG)));
+    loadConfig(VALID_FULL_CONFIG);
+    ASSERT_TRUE(isSuccess(gw->setConfig(jsonConfig)));
     ASSERT_TRUE(isError(gw->activate()));
 }

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
@@ -26,6 +26,23 @@ void SoftwareContainerGatewayTest::givenContainerIsSet(Gateway *gw)
     m_sc->addGateway(gw);
 }
 
+void SoftwareContainerGatewayTest::loadConfig(const std::string &config)
+{
+    if (nullptr != jsonConfig) {
+        json_decref(jsonConfig);
+    }
+
+    json_error_t err;
+    jsonConfig = json_loads(config.c_str(), 0, &err);
+}
+
+void SoftwareContainerGatewayTest::TearDown()
+{
+    if (nullptr != jsonConfig) {
+        json_decref(jsonConfig);
+    }
+}
+
 void SoftwareContainerTest::run()
 {
     m_ml = Glib::MainLoop::create(m_context);

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.h
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.h
@@ -64,5 +64,10 @@ public:
     SoftwareContainerGatewayTest() { }
     ~SoftwareContainerGatewayTest() { }
 
+    json_t *jsonConfig;
+
+    void TearDown() override;
+
     void givenContainerIsSet(Gateway *gw);
+    void loadConfig(const std::string &config);
 };

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgateway.cpp
@@ -33,7 +33,7 @@ DBusGateway::~DBusGateway()
 {
 }
 
-ReturnCode DBusGateway::setConfig(const std::string &config)
+ReturnCode DBusGateway::setConfig(const json_t *config)
 {
     try {
         log_debug() << "Setting config for dbus session bus";

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgateway.h
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgateway.h
@@ -37,7 +37,7 @@ public:
     /**
      * @brief Sets config for both dbus session instances
      */
-    virtual ReturnCode setConfig(const std::string &config) override;
+    virtual ReturnCode setConfig(const json_t *config) override;
 
     /**
      * @brief Activates both dbus session instances

--- a/libsoftwarecontainer/src/gateway/gateway.h
+++ b/libsoftwarecontainer/src/gateway/gateway.h
@@ -106,7 +106,7 @@ public:
      *
      * @throws GatewayError If called on an already activated gateway.
      */
-    virtual ReturnCode setConfig(const std::string &config);
+    virtual ReturnCode setConfig(const json_t *config);
 
     /**
      * @brief Applies any configuration set by setConfig()
@@ -185,11 +185,6 @@ protected:
     virtual bool teardownGateway() = 0;
 
 private:
-    /**
-     * @brief A help function for setConfig to log an error and decref the json element
-     */
-    void setConfigRollback(std::string message, json_t *element);
-
     std::shared_ptr<ContainerAbstractInterface> m_container;
     const char *m_id = nullptr;
     GatewayState m_state = GatewayState::CREATED;

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -193,15 +193,11 @@ ReturnCode SoftwareContainer::configureGateways(const GatewayConfiguration &gwCo
 
         json_t *config = gwConfig.config(gatewayId);
         if (config != nullptr) {
-            std::string configStr = json_dumps(config,0);
-            log_debug() << "Configuring gateway \""
-                        << gatewayId
-                        << "\" with config: "
-                        << configStr;
+            log_debug() << "Configuring gateway: " << gatewayId;
             try {
-                ReturnCode configurationResult = gateway->setConfig(configStr);
+                ReturnCode configurationResult = gateway->setConfig(config);
                 if (isError(configurationResult)) {
-                    log_error() << "Failed to apply gateway configuration: " << configStr;
+                    log_error() << "Failed to apply gateway configuration";
                     return configurationResult;
                 }
             } catch (GatewayError &error) {
@@ -210,7 +206,7 @@ ReturnCode SoftwareContainer::configureGateways(const GatewayConfiguration &gwCo
                  * as it means one or more capabilities are broken.
                  */
                 log_error() << "Fatal error when configuring gateway \""
-                            << gatewayId << "\" : " << error.what();
+                            << gatewayId << "\": " << error.what();
                 throw error;
             }
             json_decref(config);


### PR DESCRIPTION
It took std::string before, and through a long way of not updating
in all places when we update in one place, we ended up in a situation
where the library took a GatewayConfiguration object (which wraps a
bunch of json_t) and the SoftwareContainer class would convert this to a
string, which the Gateway class would convert back into json_t.

TL;DR: It is all json_t now.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>