### PR TITLE
fixes a nullptr bug in component test

### DIFF
--- a/libsoftwarecontainer/component-test/softwarecontainer_test.h
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.h
@@ -64,7 +64,7 @@ public:
     SoftwareContainerGatewayTest() { }
     ~SoftwareContainerGatewayTest() { }
 
-    json_t *jsonConfig;
+    json_t *jsonConfig = nullptr;
 
     void TearDown() override;
 


### PR DESCRIPTION
Well, this is embarrasing... (this caused a segfault in the component tests)

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>