### PR TITLE
jsonparser: not finding key is warning, not error

### DIFF
--- a/common/jsonparser.cpp
+++ b/common/jsonparser.cpp
@@ -52,7 +52,7 @@ bool JSONParser::read(const json_t *element, const char *key, std::string &resul
 {
     json_t *value = json_object_get(element, key);
     if (!value) {
-        log_error() << "Could not fetch \"" << key << "\" from json element";
+        log_warning() << "Could not fetch \"" << key << "\" from json element";
         return false;
     }
 
@@ -69,7 +69,7 @@ bool JSONParser::read(const json_t *element, const char *key, bool &result)
 {
     json_t *value = json_object_get(element, key);
     if (!value) {
-        log_error() << "Could not fetch \"" << key << "\" from json element";
+        log_warning() << "Could not fetch \"" << key << "\" from json element";
         return false;
     }
 
@@ -86,7 +86,7 @@ bool JSONParser::read(const json_t *element, const char *key, int &result)
 {
     json_t *value = json_object_get(element, key);
     if (!value) {
-        log_error() << "Could not fetch \"" << key << "\" from json element";
+        log_warning() << "Could not fetch \"" << key << "\" from json element";
         return false;
     }
 


### PR DESCRIPTION
It is common to check for a key and that it may be optional. This way,
not finding it still generates a "return false", but only a warning.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>