### PR TITLE
networkgw: Uses the bridge device from config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,13 +247,13 @@ if(ENABLE_NETWORKGATEWAY)
     add_string_config(${SC_CONFIG_GROUP} BRIDGE_IP "10.0.3.1" "10.0.3.1")
     add_string_config(${SC_CONFIG_GROUP} BRIDGE_NETADDR "10.0.3.0" "10.0.3.0")
     add_string_config(${SC_CONFIG_GROUP} BRIDGE_NETMASK "255.255.255.0" "255.255.255.0")
-    add_integer_config(${SC_CONFIG_GROUP} BRIDGE_NETMASK_BITS 24 24)
+    add_integer_config(${SC_CONFIG_GROUP} BRIDGE_NETMASK_BITLENGTH 24 24)
 
     # All these are mandatory if we are configured for network
     make_config_mandatory(${SC_CONFIG_GROUP} CREATE_BRIDGE)
     make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_DEVICE)
     make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_IP)
-    make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_NETMASK_BITS)
+    make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_NETMASK_BITLENGTH)
     make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_NETADDR)
     make_config_mandatory(${SC_CONFIG_GROUP} BRIDGE_NETMASK)
 
@@ -266,7 +266,7 @@ if(ENABLE_NETWORKGATEWAY)
     add_definitions(-DBRIDGE_IP_TESTING="${SC_BRIDGE_IP}")
     add_definitions(-DBRIDGE_NETADDR_TESTING="${SC_BRIDGE_NETADDR}")
     add_definitions(-DBRIDGE_NETMASK_TESTING="${SC_BRIDGE_NETMASK}")
-    add_definitions(-DBRIDGE_NETMASK_BITS_TESTING="${SC_BRIDGE_NETMASK_BITS}")
+    add_definitions(-DBRIDGE_NETMASK_BITLENGTH_TESTING="${SC_BRIDGE_NETMASK_BITLENGTH}")
 
     # Install the actual script
     install(FILES ${CMAKE_SOURCE_DIR}/scripts/setup_softwarecontainer.sh DESTINATION bin

--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -77,7 +77,7 @@ public:
                                      "bridge-device = " + std::string(BRIDGE_DEVICE_TESTING) + "\n"
                                      "bridge-ip = " + std::string(BRIDGE_IP_TESTING) + "\n"
                                      "bridge-netmask = " + std::string(BRIDGE_NETMASK_TESTING) + "\n"
-                                     "bridge-netmask-bits = " + std::string(BRIDGE_NETMASK_BITS_TESTING) +"\n"
+                                     "bridge-netmask-bitlength = " + std::string(BRIDGE_NETMASK_BITLENGTH_TESTING) +"\n"
                                      "bridge-netaddr = " + std::string(BRIDGE_NETADDR_TESTING) + "\n"
 #endif
                                      "shutdown-timeout = 1\n"

--- a/agent/softwarecontainer-config.network.in
+++ b/agent/softwarecontainer-config.network.in
@@ -11,7 +11,7 @@
 @SC_BRIDGE_NETMASK_ACTIVATE@bridge-netmask = @SC_BRIDGE_NETMASK_CONFIG_FILE_VAR@
 
 # Netmask bits for the network bridge
-@SC_BRIDGE_NETMASK_BITS_ACTIVATE@bridge-netmask-bits = @SC_BRIDGE_NETMASK_BITS_CONFIG_FILE_VAR@
+@SC_BRIDGE_NETMASK_BITLENGTH_ACTIVATE@bridge-netmask-bitlength = @SC_BRIDGE_NETMASK_BITLENGTH_CONFIG_FILE_VAR@
 
 # Network address part for the network bridge ip
 @SC_BRIDGE_NETADDR_ACTIVATE@bridge-netaddr = @SC_BRIDGE_NETADDR_CONFIG_FILE_VAR@

--- a/agent/src/config/configdefinition.cpp
+++ b/agent/src/config/configdefinition.cpp
@@ -70,7 +70,7 @@ const std::string ConfigDefinition::SC_BRIDGE_DEVICE_KEY = "bridge-device";
 const std::string ConfigDefinition::SC_BRIDGE_IP_KEY = "bridge-ip";
 const std::string ConfigDefinition::SC_BRIDGE_NETADDR_KEY = "bridge-netaddr";
 const std::string ConfigDefinition::SC_BRIDGE_NETMASK_KEY = "bridge-netmask";
-const std::string ConfigDefinition::SC_BRIDGE_NETMASK_BITS_KEY = "bridge-netmask-bits";
+const std::string ConfigDefinition::SC_BRIDGE_NETMASK_BITLENGTH_KEY = "bridge-netmask-bitlength";
 #endif
 
 /*
@@ -99,10 +99,10 @@ const ConfigItems CONFIGS
                     ConfigDefinition::convertDefineToFlag(
                         SC_BRIDGE_IP_MANDATORY_FLAG /* set by cmake */)),
     std::make_tuple(ConfigDefinition::SC_GROUP,
-                    ConfigDefinition::SC_BRIDGE_NETMASK_BITS_KEY,
+                    ConfigDefinition::SC_BRIDGE_NETMASK_BITLENGTH_KEY,
                     ConfigType::Integer,
                     ConfigDefinition::convertDefineToFlag(
-                        SC_BRIDGE_NETMASK_BITS_MANDATORY_FLAG /* set by cmake */)),
+                        SC_BRIDGE_NETMASK_BITLENGTH_MANDATORY_FLAG /* set by cmake */)),
     std::make_tuple(ConfigDefinition::SC_GROUP,
                     ConfigDefinition::SC_BRIDGE_NETMASK_KEY,
                     ConfigType::String,

--- a/agent/src/config/configdefinition.h
+++ b/agent/src/config/configdefinition.h
@@ -87,7 +87,7 @@ public:
     static const std::string SC_BRIDGE_IP_KEY;
     static const std::string SC_BRIDGE_NETADDR_KEY;
     static const std::string SC_BRIDGE_NETMASK_KEY;
-    static const std::string SC_BRIDGE_NETMASK_BITS_KEY;
+    static const std::string SC_BRIDGE_NETMASK_BITLENGTH_KEY;
 #endif
 
     static MandatoryConfigs mandatory();

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -58,7 +58,7 @@ SoftwareContainerAgent::SoftwareContainerAgent(Glib::RefPtr<Glib::MainContext> m
     std::string bridgeNetmask = m_config->getStringValue(ConfigDefinition::SC_GROUP,
                                                          ConfigDefinition::SC_BRIDGE_NETMASK_KEY);
     int bridgeNetmaskBits = m_config->getIntValue(ConfigDefinition::SC_GROUP,
-                                                  ConfigDefinition::SC_BRIDGE_NETMASK_BITS_KEY);
+                                                  ConfigDefinition::SC_BRIDGE_NETMASK_BITLENGTH_KEY);
     std::string bridgeNetAddr = m_config->getStringValue(ConfigDefinition::SC_GROUP,
                                                  ConfigDefinition::SC_BRIDGE_NETADDR_KEY);
 #endif // ENABLE_NETWORKGATEWAY

--- a/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
@@ -29,7 +29,7 @@ public:
         NetworkGateway(11, // container id
                        std::string(BRIDGE_DEVICE_TESTING),
                        std::string(BRIDGE_IP_TESTING), // bridge ip
-                       std::stoi(BRIDGE_NETMASK_BITS_TESTING)) // bridge netmask 
+                       std::stoi(BRIDGE_NETMASK_BITLENGTH_TESTING)) // bridge netmask 
     {
     }
 

--- a/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
@@ -25,8 +25,8 @@ class MockNetworkGateway :
     public NetworkGateway
 {
 public:
-    MockNetworkGateway() :
-        NetworkGateway(11, // container id
+    MockNetworkGateway(uint32_t containerID) :
+        NetworkGateway(containerID,
                        std::string(BRIDGE_DEVICE_TESTING),
                        std::string(BRIDGE_IP_TESTING), // bridge ip
                        std::stoi(BRIDGE_NETMASK_BITLENGTH_TESTING)) // bridge netmask 
@@ -43,7 +43,10 @@ protected:
 
     void SetUp() override
     {
-        gw = new ::testing::NiceMock<MockNetworkGateway>();
+        srand(time(NULL));
+        uint32_t containerID = rand() % 100;
+
+        gw = new ::testing::NiceMock<MockNetworkGateway>(containerID);
         SoftwareContainerTest::SetUp();
         ::testing::DefaultValue<ReturnCode>::Set(ReturnCode::SUCCESS);
     }

--- a/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/networkgateway_componenttest.cpp
@@ -26,10 +26,10 @@ class MockNetworkGateway :
 {
 public:
     MockNetworkGateway() :
-        NetworkGateway(1, // container id
+        NetworkGateway(11, // container id
+                       std::string(BRIDGE_DEVICE_TESTING),
                        std::string(BRIDGE_IP_TESTING), // bridge ip
-                       std::stoi(BRIDGE_NETMASK_BITS_TESTING) // netmask bits
-        )
+                       std::stoi(BRIDGE_NETMASK_BITS_TESTING)) // bridge netmask 
     {
     }
 

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<SoftwareContainerConfig> SoftwareContainerTest::createConfig()
         std::string(BRIDGE_DEVICE_TESTING),// Should be set be CMake
         std::string(BRIDGE_IP_TESTING),// Should be set be CMake
         std::string(BRIDGE_NETMASK_TESTING),// Should be set be CMake
-        std::stoi(BRIDGE_NETMASK_BITS_TESTING),// Should be set be CMake
+        std::stoi(BRIDGE_NETMASK_BITLENGTH_TESTING),// Should be set be CMake
         std::string(BRIDGE_NETADDR_TESTING),// Should be set be CMake
 #endif // ENABLE_NETWORKGATEWAY
         LXC_CONFIG_PATH_TESTING, // Should be set be CMake

--- a/libsoftwarecontainer/src/gateway/network/networkgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/network/networkgateway.cpp
@@ -27,11 +27,13 @@
 namespace softwarecontainer {
 
 NetworkGateway::NetworkGateway(const int32_t id,
+                               const std::string bridgeDevice,
                                const std::string gateway,
                                const uint8_t maskBits) :
     Gateway(ID),
     m_netmask(maskBits),
     m_gateway(gateway),
+    m_bridgeDevice(bridgeDevice),
     m_interfaceInitialized(false),
     m_containerID(id)
 {
@@ -206,19 +208,16 @@ ReturnCode NetworkGateway::down()
     }
 }
 
-/*
- * TODO: Use value from the config instead of define here.
- */
 ReturnCode NetworkGateway::isBridgeAvailable()
 {
     Netlink::LinkInfo iface;
-    if (isError(m_netlinkHost.findLink(SC_BRIDGE_DEVICE, iface))) {
-        log_error() << "Could not find " << SC_BRIDGE_DEVICE << " in the host";
+    if (isError(m_netlinkHost.findLink(m_bridgeDevice.c_str(), iface))) {
+        log_error() << "Could not find " << m_bridgeDevice << " in the host";
     }
 
     std::vector<Netlink::AddressInfo> addresses;
     if (isError(m_netlinkHost.findAddresses(iface.first.ifi_index, addresses))) {
-        log_error() << "Could not fetch addresses for " << SC_BRIDGE_DEVICE << " in the host";
+        log_error() << "Could not fetch addresses for " << m_bridgeDevice << " in the host";
     }
 
     return m_netlinkHost.hasAddress(addresses, AF_INET, m_gateway.c_str());

--- a/libsoftwarecontainer/src/gateway/network/networkgateway.h
+++ b/libsoftwarecontainer/src/gateway/network/networkgateway.h
@@ -57,6 +57,7 @@ public:
      * @throws SoftwareContainerError if there is an error during initialization.
      */
     NetworkGateway(const int32_t id,
+                   const std::string bridgeDevice,
                    const std::string gateway,
                    const uint8_t maskBits);
 
@@ -123,6 +124,7 @@ private:
     struct in_addr m_ip;
     uint32_t m_netmask;
     std::string m_gateway;
+    std::string m_bridgeDevice;
 
     std::vector<IPTableEntry> m_entries;
 

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -119,6 +119,7 @@ ReturnCode SoftwareContainer::init()
 #ifdef ENABLE_NETWORKGATEWAY
     try {
         addGateway(new NetworkGateway(m_containerID,
+                                      m_config->bridgeDevice(),
                                       m_config->bridgeIPAddress(),
                                       m_config->bridgeNetmaskBitLength()));
     } catch (ReturnCode failure) {


### PR DESCRIPTION
We used to have a cmake define here instead.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>