### PR TITLE
CMake: Don't include doc in ALL.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,14 +83,6 @@ node {
                                      softwarecontainer clang \"${buildParams}\"")
         }
 
-        stage('User documentation') {
-            runInVagrant(workspace, 'cd softwarecontainer/build && make user-doc')
-        }
-
-        stage('API documentation') {
-            runInVagrant(workspace, 'cd softwarecontainer/build && make api-doc')
-        }
-
         stage('UnitTest') {
             runInVagrant(workspace, "cd softwarecontainer && ./build/run-unit-tests.py")
         }


### PR DESCRIPTION
One can simply type "make doc" to build them.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>