### PR TITLE
Remove log_ functions from stuff run in container

### DIFF
--- a/libsoftwarecontainer/src/gateway/network/iptableentry.cpp
+++ b/libsoftwarecontainer/src/gateway/network/iptableentry.cpp
@@ -19,6 +19,7 @@
 
 #include "iptableentry.h"
 #include "gateway/gateway.h"
+#include <iostream>
 
 namespace softwarecontainer {
 
@@ -29,20 +30,20 @@ bool IPTableEntry::applyRules()
 
             for (auto proto : rule.protocols) {
                 if (!insertCommand(interpretRuleWithProtocol(rule, proto))) {
-                    log_error() << "Couldn't apply the rule " << rule.target;
+                    std::cerr << "Couldn't apply the rule " << rule.target << std::endl;
                     return false;
                 }
             }
 
         } else if (!insertCommand(interpretRule(rule))) {
-            log_error() << "Couldn't apply the rule " << rule.target;
+            std::cerr << "Couldn't apply the rule " << rule.target << std::endl;
             return false;
         }
     }
 
     if (!insertCommand(interpretPolicy())) {
-        log_error() << "Unable to set policy " << convertTarget(m_defaultTarget)
-                    << " for " << m_type;
+        std::cerr << "Unable to set policy " << convertTarget(m_defaultTarget)
+                  << " for " << m_type << std::endl;
         return false;
     }
 
@@ -148,7 +149,7 @@ std::string IPTableEntry::interpretRule(Rule rule)
 std::string IPTableEntry::interpretPolicy()
 {
     if (m_defaultTarget != Target::ACCEPT && m_defaultTarget != Target::DROP) {
-        log_error() << "Wrong default target : " << convertTarget(m_defaultTarget);
+        std::cerr << "Wrong default target : " << convertTarget(m_defaultTarget) << std::endl;
         return "";
     }
     std::string iptableCommand = "iptables -P " + m_type + " " + convertTarget(m_defaultTarget);
@@ -159,19 +160,19 @@ std::string IPTableEntry::interpretPolicy()
 
 bool IPTableEntry::insertCommand(std::string command)
 {
-    log_debug() << "Add network rule : " <<  command;
+    std::cout << "Add network rule : " <<  command << std::endl;
 
     try {
         Glib::spawn_command_line_sync(command);
 
     } catch (Glib::SpawnError e) {
-        log_error() << "Failed to spawn " << command << ": code " << e.code()
-                               << " msg: " << e.what();
+        std::cerr << "Failed to spawn " << command << ": code " << e.code()
+                  << " msg: " << e.what() << std::endl;
 
         return false;
     } catch (Glib::ShellError e) {
-        log_error() << "Failed to call " << command << ": code " << e.code()
-                                       << " msg: " << e.what();
+        std::cerr << "Failed to call " << command << ": code " << e.code()
+                  << " msg: " << e.what() << std::endl;
         return false;
     }
 

--- a/libsoftwarecontainer/src/gateway/network/netlink.cpp
+++ b/libsoftwarecontainer/src/gateway/network/netlink.cpp
@@ -23,6 +23,7 @@
 
 #include <unistd.h> // getpid(), getpagesize()
 #include <string.h> // memcpy, memset etc
+#include <iostream> // cout
 
 namespace softwarecontainer {
 
@@ -346,13 +347,12 @@ bool Netlink::hasAddress(const std::vector<AddressInfo> &haystack,
 
             // It is ok here for inet_ntop to fail (data could be bad)
             if (inet_ntop(addressFamily, data, out, sizeof(out)) && strcmp(out, needle) == 0) {
-                log_debug() << "Netlink has address";
                 return true;
             }
         }
     }
 
-    log_debug() << "Netlink does not have address";
+    std::cout << "Netlink does not have address" << std::endl;
     return false;
 }
 
@@ -462,21 +462,21 @@ bool Netlink::getKernelDump()
     netlink_request<rtgenmsg> link_msg = createMessage<rtgenmsg>(RTM_GETLINK, NLM_F_DUMP);
     link_msg.pay.rtgen_family = AF_PACKET;
     if (!sendMessage(link_msg)) {
-        log_error() << "Could not send link message";
+        std::cerr << "Could not send link message" << std::endl;
         return false;
     }
 
     netlink_request<rtgenmsg> addr_msg = createMessage<rtgenmsg>(RTM_GETADDR, NLM_F_DUMP);
     addr_msg.pay.rtgen_family = AF_PACKET;
     if (!sendMessage(addr_msg)) {
-        log_error() << "Could not send address message";
+        std::cerr << "Could not send address message" << std::endl;
         return false;
     }
 
     netlink_request<rtgenmsg> route_msg = createMessage<rtgenmsg>(RTM_GETROUTE, NLM_F_DUMP);
     route_msg.pay.rtgen_family = AF_PACKET;
     if (!sendMessage(route_msg)) {
-        log_error() << "Could not send route message";
+        std::cerr << "Could not send route message" << std::endl;
         return false;
     }
 
@@ -487,7 +487,7 @@ bool Netlink::getKernelDump()
 bool Netlink::checkKernelDump()
 {
     if (!m_hasKernelDump && !getKernelDump()) {
-        log_error() << "Could not get cache dump from kernel";
+        std::cerr << "Could not get cache dump from kernel" << std::endl;
         return false;
     }
 


### PR DESCRIPTION
Currently, due to how DLT works, using ivi-logging with
DLT will disable logging inside containers, and instead
just hang, which is not good. We've cleaned this before,
but missed that it sneaked back in.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>