### PR TITLE
Always set return value to -1 on test failure

### DIFF
--- a/scripts/run-component-tests.py
+++ b/scripts/run-component-tests.py
@@ -119,7 +119,7 @@ shutil.rmtree(xdg_path);
 retval = 0
 for name,exitCode in testSuites.items():
     if exitCode is not 0:
-        retval += exitCode
+        retval = -1
         red = "\033[1;31m"
         reset = "\033[0;0m"
         errorString = "*** The {} failed with exit code {} ***".format(name, exitCode)

--- a/scripts/run-unit-tests.py
+++ b/scripts/run-unit-tests.py
@@ -56,7 +56,7 @@ runTestSuite("./libsoftwarecontainer/unit-test/softwarecontainer-unit-test", "Li
 retval = 0
 for name, exitCode in testSuites.items():
     if exitCode is not 0:
-        retval += exitCode
+        retval = -1
         red = "\033[1;31m"
         reset = "\033[0;0m"
         errorString = "*** The {} failed with exit code {} ***".format(name, exitCode)


### PR DESCRIPTION
Since exit codes are returned modulo 256, an exit code of
256 will be equal to 0, which indicates no problem. This is
of course not desired, so changing it to -1 in case of any
error.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>