### PR TITLE
Fixes some logging in container + service test lib

### DIFF
--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -187,7 +187,7 @@ class Container():
         return True if result == dbus.Boolean(True) else False
 
 
-    def launch_command(self, binary, stdout="/tmp/stdout", env={"": ""}):
+    def launch_command(self, binary, stdout="/tmp/stdout", env={}):
         """ Calls LaunchCommand on the Agent D-Bus interface.
 
             The user must pass the actual command to run. This is passed as a string argument


### PR DESCRIPTION
The service test lib would pass an empty env var pair to the
agent as a default, instead of a truly empty dict.

The logging of environment variables sent to a function was
causing problems when being used with DLT, so it has been
reworked to print one at a time, and to not add any newlines
manually.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>