### PR TITLE
iptables/busybox are mounted instead of copied

### DIFF
--- a/doc/chapters/lxc/index.rst
+++ b/doc/chapters/lxc/index.rst
@@ -17,9 +17,9 @@ Create basic rootfs
 ^^^^^^^^^^^^^^^^^^^
 The rootfs created is a basic FHS-like (`FHS <https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard>`_)
 structure, although stripped down, with the added ``/gateways`` directory. LXC template will also
-create two paths, that will be substituted by CMake - ``${CMAKE_INSTALL_PREFIX}`` and
-``${ADDITIONAL_FOLDER_MOUNTS}``. Furthermore, a root user and group will be created, and some
-configuration options will be set in the following three areas:
+create the path pointed by CMake with the variable ``${CMAKE_INSTALL_PREFIX}``.  Furthermore, a root
+user and group will be created, and some configuration options will be set in the following three
+areas:
 
 * ``/etc/pulse/client.conf`` - tell pulse not to use shm
 * ``/etc/machine-id`` - populated with a dbus-uuid

--- a/libsoftwarecontainer/lxc-softwarecontainer.in
+++ b/libsoftwarecontainer/lxc-softwarecontainer.in
@@ -56,6 +56,7 @@ create_rootfs()
         $rootfs/usr/lib \
         $rootfs/usr/lib64 \
         $rootfs/usr/sbin \
+        $rootfs/sys \
         $rootfs/tmp \
         $rootfs/gateways \
         $rootfs/${CMAKE_INSTALL_PREFIX} \

--- a/libsoftwarecontainer/lxc-softwarecontainer.in
+++ b/libsoftwarecontainer/lxc-softwarecontainer.in
@@ -70,38 +70,53 @@ create_rootfs()
     echo "root:x:0:0:root:/root:/bin/sh" >> $rootfs/etc/passwd
     echo "root:x:0:root" >> $rootfs/etc/group
 
-    # We don't have an shm fs mounted, so tell pulse not to use it.
+    # We may not have a shm fs mounted, so tell pulse not to use it.
     echo "disable-shm=yes" >> $rootfs/etc/pulse/client.conf
+
     # We generate a unique machine id for D-Bus.
     dbus-uuidgen --ensure=$rootfs/etc/machine-id
+
     # Copy DNS info into the guest, if available
     if [ -e /etc/resolv.conf ]; then
         cp /etc/resolv.conf $rootfs/etc/resolv.conf
     fi
 
-    return $res
-}
-
-configure_busybox()
-{
-    rootfs=$1
-
-    which busybox >/dev/null 2>&1
+    BUSYBOX=$(which busybox)
     if [ $? -ne 0 ]; then
         echo "busybox executable is not accessible"
         return 1
     fi
 
-    # Copy the busybox binary into the rootfs
-    cp $(which busybox) $rootfs/bin
+    # We will bind-mount busybox to this location in the container later
+    touch $rootfs/bin/busybox
+    chmod 755 $rootfs/bin/busybox
+
+    cd $rootfs/bin || return 1
+    COMMANDS=$($BUSYBOX --list)
+    for COMMAND in $COMMANDS; do
+        ln -s busybox $COMMAND
+    done
+
+    INITLXCFILE=$(which init.lxc)
     if [ $? -ne 0 ]; then
-        echo "failed to copy busybox in the rootfs"
+        echo "init.lxc not found"
         return 1
     fi
+    touch $rootfs/bin/init.lxc
+    chmod 755 $rootfs/bin/init.lxc
 
-    # Symlink to busybox for the commands it supports
-    cd $rootfs/bin || return 1
-    ./busybox --list | xargs -n1 ln -s busybox
+    # If we have network enabled, we need iptables
+    if [ ${ENABLE_NETWORKGATEWAY} = "ON" ]; then
+        IPTABLES=$(which iptables)
+        if [ $? -ne 0 ]; then
+            echo "iptables executable is not accessible"
+            return 1
+        fi
+
+        # We will bind-mount iptables to this location in the container later
+        touch $rootfs/bin/iptables
+        chmod 755 $rootfs/bin/busybox
+    fi
 
     return 0
 }
@@ -110,28 +125,23 @@ copy_configuration()
 {
     path=$1
     rootfs=$2
-    name=$3
 
     # Set some non-static mount points, the rest are already in the config file
     echo "lxc.rootfs = $rootfs" >> $path/config
     echo "lxc.mount.entry = ${CMAKE_INSTALL_PREFIX} $rootfs/${CMAKE_INSTALL_PREFIX} none ro,bind 0 0" >> $path/config
 
-    # Bind-mount the directory containing init.lxc to /usr/sbin. This is typically
-    # /usr/sbin on the host as well.
-    INITLXCFILE=`which init.lxc`
-    if [ $? -ne 0 ]; then
-        echo "Error in template: init.lxc not found, unable to mount containing directory to /usr/sbin in container"
-        return 1
+    # Bind-mount the necessary binaries into the container
+    echo "lxc.mount.entry = $(which init.lxc) bin/init.lxc none ro,bind 0 0" >> $path/config
+    echo "lxc.mount.entry = $(which busybox) bin/busybox none ro,bind 0 0" >> $path/config
+
+    if [ ${ENABLE_NETWORKGATEWAY} = "ON" ]; then
+        echo "lxc.mount.entry = $(which iptables) bin/iptables none ro,bind 0 0" >> $path/config
     fi
-    echo "lxc.mount.entry = $(dirname $INITLXCFILE) $rootfs/usr/sbin none ro,bind 0 0" >> $path/config
 
     # If the gateway dir variable is set, add a mount entry for that one also.
-    # The gateway folder needs to be writable since wayland requires some extra
-    # files to be created by the client in the folder where the wayland socket
-    # is located
     if [ -n "$GATEWAY_DIR" ]; then
         echo "lxc.mount.entry = $GATEWAY_DIR gateways none rw,bind 0 0" >> $path/config
-        chmod go+rwx $GATEWAY_DIR
+        chmod 777 $GATEWAY_DIR
     fi
 }
 
@@ -180,19 +190,13 @@ if [ -z "$rootfs" ]; then
     fi
 fi
 
-create_rootfs $rootfs $name
+create_rootfs $rootfs
 if [ $? -ne 0 ]; then
-    echo "failed to create softwarecontainer rootfs"
+    echo "failed to set up softwarecontainer rootfs"
     exit 1
 fi
 
-configure_busybox $rootfs
-if [ $? -ne 0 ]; then
-    echo "failed to configure busybox in the rootfs"
-    exit 1
-fi
-
-copy_configuration $path $rootfs $name
+copy_configuration $path $rootfs
 if [ $? -ne 0 ]; then
     echo "failed to write configuration file"
     exit 1

--- a/libsoftwarecontainer/lxc-softwarecontainer.in
+++ b/libsoftwarecontainer/lxc-softwarecontainer.in
@@ -34,8 +34,6 @@
 create_rootfs()
 {
     rootfs=$1
-    name=$2
-    res=0
 
     # This is the rootfs tree in the container. Apart from the files we
     # create below, this will be empty, and most directories will be bind
@@ -59,8 +57,7 @@ create_rootfs()
         $rootfs/sys \
         $rootfs/tmp \
         $rootfs/gateways \
-        $rootfs/${CMAKE_INSTALL_PREFIX} \
-        ${ADDITIONAL_FOLDER_MOUNTS}"
+        $rootfs/${CMAKE_INSTALL_PREFIX}"
 
     # The tree needs to be writeable for the owner and read/execute for all
     mkdir -p $tree || return 1
@@ -145,15 +142,9 @@ copy_configuration()
     fi
 }
 
-usage()
-{
-    echo "$1 -h|--help -b|--buffer -p|--path=<path>|--rootfs=<path>"
-    return 0
-}
-
-options=$(getopt -o hp:n: -l help,path:,name:,rootfs: -- "$@")
+options=$(getopt -o p:n: -l path:,name:,rootfs: -- "$@")
 if [ $? -ne 0 ]; then
-    usage $(basename $0)
+    echo "Usage: $(basename $0) -p|--path=<path> --rootfs=<path>"
     exit 1
 fi
 eval set -- "$options"
@@ -161,9 +152,7 @@ eval set -- "$options"
 while true
 do
     case "$1" in
-        -h|--help)      usage $0 && exit 0;;
         -p|--path)      path=$2; shift 2;;
-        -n|--name)      name=$2; shift 2;;
         --rootfs)       rootfs=$2; shift 2;;
         --)             shift 1; break ;;
         *)              break ;;

--- a/libsoftwarecontainer/softwarecontainer.conf.in
+++ b/libsoftwarecontainer/softwarecontainer.conf.in
@@ -12,15 +12,13 @@ lxc.haltsignal = SIGKILL
 @NETWORK_LXC_CONF@
 
 lxc.mount.entry = /sbin sbin none ro,bind 0 0
+# Auto-mount /proc and /sys with reasonable settings
+lxc.mount.auto = proc sys
+
+# Note: mounting all of /usr includes /usr/bin, /usr/lib64 and /usr/local.
 lxc.mount.entry = /usr usr none ro,bind 0 0
 lxc.mount.entry = /lib lib none ro,bind 0 0
-lxc.mount.entry = /usr/lib usr/lib none ro,bind 0 0
-lxc.mount.entry = /proc proc proc nosuid,nodev,noexec 0 0
 
 # These are optional, as they may not exist in the host. If they exist
 # they will be bind mounted from host to container.
 lxc.mount.entry = /lib64 lib64 none ro,bind,optional 0 0
-lxc.mount.entry = /usr/lib64 usr/lib64 none ro,bind,optional 0 0
-
-lxc.mount.entry = /usr/local/lib usr/local/lib none ro,bind,optional 0 0
-lxc.mount.entry = /usr/local/lib64 usr/local/lib64 none ro,bind,optional 0 0

--- a/libsoftwarecontainer/softwarecontainer.conf.in
+++ b/libsoftwarecontainer/softwarecontainer.conf.in
@@ -11,7 +11,6 @@ lxc.haltsignal = SIGKILL
 
 @NETWORK_LXC_CONF@
 
-lxc.mount.entry = /sbin sbin none ro,bind 0 0
 # Auto-mount /proc and /sys with reasonable settings
 lxc.mount.auto = proc sys
 


### PR DESCRIPTION
Also adds proc and sys as lxc.mount.auto entries.

Plus some general cleanup in the LXC template

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>