### PR TITLE
bind-mounting creates paths inside the container

### DIFF
--- a/libsoftwarecontainer/component-test/softwarecontainerlib_componenttest.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainerlib_componenttest.cpp
@@ -270,6 +270,15 @@ TEST_F(SoftwareContainerApp, TestFileMounting) {
     // Now file should be available
     job->start();
     ASSERT_EQ(job->wait(), EXISTENT);
+
+    // Test that we can mount to some place where there is something else
+    // mounted higher up in the hierarchy (in this case, /dev)
+    ASSERT_TRUE(bindMountInContainer("/dev/shm", "/dev/shm", false));
+    auto jobShm = getSc().createFunctionJob([&] () {
+        return isDirectory("/dev/shm") ? EXISTENT : NON_EXISTENT;
+    });
+    jobShm->start();
+    ASSERT_EQ(jobShm->wait(), EXISTENT);
 }
 
 /**

--- a/libsoftwarecontainer/src/container.h
+++ b/libsoftwarecontainer/src/container.h
@@ -114,6 +114,11 @@ public:
                  int stdout = 1,
                  int stderr = 2);
 
+    /*
+     * @brief Start a function inside the container.
+     *
+     * The function executes as a separate process.
+     */
     bool execute(ExecFunction function,
                  pid_t *pid,
                  const EnvironmentVariables &variables = EnvironmentVariables(),
@@ -121,6 +126,15 @@ public:
                  int stdout = 1,
                  int stderr = 2);
 
+    /**
+     * @brief synchronous version of execute
+     */
+    bool executeSync(ExecFunction function,
+                     pid_t *pid,
+                     const EnvironmentVariables &variables = EnvironmentVariables(),
+                     int stdin = -1,
+                     int stdout = 1,
+                     int stderr = 2);
 
     /**
      * @brief Tries to bind mount a path from host to container
@@ -220,37 +234,8 @@ private:
     static int executeInContainerEntryFunction(void *param);
 
     /**
-     * @brief Tries to bind mount a file in the container
-     *
-     * Any missing parent paths will be created.
-     *
-     * @param pathInHost The path to the file that shall be bind mounted on the host system.
-     * @param pathInContainer Where to mount the file in the container.
-     * @param readonly Sets if the mount should be read only or read write
-     *
-     * @return SUCCESS if everything worked as expected, FAILURE otherwise.
+     * Handles bind-mounting
      */
-    bool bindMountFileInContainer(const std::string &pathInHost,
-                                  const std::string &pathInContainer,
-                                  const std::string &tempFile,
-                                  bool readonly = true);
-
-    /**
-     * @brief Tries to bind mount a directory in the container
-     *
-     * Any missing parent paths will be created.
-     *
-     * @param pathInHost The path to the directory that shall be bind mounted on the host system.
-     * @param pathInContainer Where to mount the file in the container.
-     * @param readonly Sets if the mount should be read only or read write
-     *
-     * @return true if everything worked as expected, false otherwise.
-     */
-    bool bindMountDirectoryInContainer(const std::string &pathInHost,
-                                       const std::string &pathInContainer,
-                                       const std::string &tempDir,
-                                       bool readonly = true);
-
     bool bindMountCore(const std::string &pathInHost,
                        const std::string &pathInContainer,
                        const std::string &tempDir,


### PR DESCRIPTION
Since various paths inside the container might be mounted over with a
tmpfs (for example /dev), we can't check the path on the rootfs in the
host, we need to do that inside the container.

If anyone wonders why there is a new way of creating parent directories, it is to avoid issues with DLT, since the utilities we have in the file toolkit uses logging macros. Once the DLT issue is fixed that can be removed.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>