### PR TITLE
Adds tests for using POSIX shared memory

### DIFF
--- a/libsoftwarecontainer/component-test/CMakeLists.txt
+++ b/libsoftwarecontainer/component-test/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(
 
 set(TEST_LIBRARY_DEPENDENCIES
     ${IVILogging_LIBRARIES}
+    rt # For SHM tests to work
     softwarecontainer
 )
 


### PR DESCRIPTION
It seems that one can mount these entries just as if they were regular files.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>