### PR TITLE
Test setting capability twice

### DIFF
--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -308,6 +308,9 @@ class SoftwareContainerAgentHandler():
             self.__rec.terminate()
             raise Exception("SoftwareContainer-agent has died for some reason")
 
+    def is_alive(self):
+        return self.__agent.poll() is None
+
     def terminate(self):
         self.__agent.terminate()
         self.__rec.terminate()


### PR DESCRIPTION
Verify that there are no crashes when setting the same
capability twice. Write a service test to verify this.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>