### PR TITLE
Check exception type

### DIFF
--- a/servicetest/capabilities/test_caps.py
+++ b/servicetest/capabilities/test_caps.py
@@ -173,6 +173,7 @@ class TestCaps(object):
             sc.start(DATA)
             with pytest.raises(DBusException) as err:
                 sc.set_capabilities(["does.not.exist"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
         finally:
             sc.terminate()
@@ -186,6 +187,7 @@ class TestCaps(object):
             sc.start(DATA)
             with pytest.raises(DBusException) as err:
                sc.set_capabilities(["test.cap"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
         finally:
             sc.terminate()
@@ -199,6 +201,7 @@ class TestCaps(object):
             sc.start(DATA)
             with pytest.raises(DBusException) as err:
                 sc.set_capabilities(["test.cap.broken-gw-config"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
         finally:
             sc.terminate()
@@ -255,7 +258,7 @@ class TestCaps(object):
                 # Set the same capability again
                 sc.set_capabilities(["test.cap.valid-dbus"])
             # The expected failure is 'Failed', not 'NoReply'
-            assert err.value.get_dbus_name() == "org.freedesktop.DBus.Error.Failed"
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
             # Verify that the Agent is still alive
             assert agent.is_alive()

--- a/servicetest/cgroups/test_cgroups.py
+++ b/servicetest/cgroups/test_cgroups.py
@@ -133,8 +133,9 @@ class TestCGroupGateway(object):
             sc = Container()
             sc.start(DATA)
 
-            with pytest.raises(DBusException):
+            with pytest.raises(DBusException) as err:
                sc.set_capabilities(["test.cap.small.threshold"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
         finally:
             sc.terminate()

--- a/servicetest/environment/test_environment.py
+++ b/servicetest/environment/test_environment.py
@@ -247,8 +247,9 @@ class TestEnvironment(object):
         try:
             sc.start(DATA)
 
-            with pytest.raises(DBusException):
+            with pytest.raises(DBusException) as err:
                sc.set_capabilities(["environment.test.cap.1"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
         finally:
             sc.terminate()

--- a/servicetest/networkgateway/test_network_gateway.py
+++ b/servicetest/networkgateway/test_network_gateway.py
@@ -172,8 +172,9 @@ class TestNetworkRules(object):
             sc = Container()
             sc.start(DATA)
 
-            with pytest.raises(DBusException):
+            with pytest.raises(DBusException) as err:
                 sc.set_capabilities(["test.cap.empty"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
             sc.launch_command("python " +
                               sc.get_bind_dir() +
@@ -199,8 +200,9 @@ class TestNetworkRules(object):
 
             sc.set_capabilities(["test.cap.policy-drop"])
 
-            with pytest.raises(DBusException):
+            with pytest.raises(DBusException) as err:
                sc.set_capabilities(["test.cap.policy-drop"])
+            assert err.value.get_dbus_name() == Container.DBUS_EXCEPTION_FAILED
 
         finally:
             sc.terminate()

--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -260,6 +260,10 @@ class Container():
     HOST_PATH = "host-path"
     READONLY = False
 
+    # Static class member used by tests to match DBusException type
+    # The "Failed" DBusException type is used by SC to indicate errors from method calls
+    DBUS_EXCEPTION_FAILED = "org.freedesktop.DBus.Error.Failed"
+
     def __init__(self):
         bus = dbus.SystemBus()
         pca_obj = bus.get_object("com.pelagicore.SoftwareContainerAgent",


### PR DESCRIPTION
In service tests, when expecting and exception, verify
that the exception type is a failure, not a crash/NoReply.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>