### PR TITLE
Added service test for caps and multiple containers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,11 +50,11 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", path: "cookbook/system-config/systemd-network-startup-timeout.sh"
 
     # Use apt-cacher on our apt cache server
-    if ENV['APT_CACHE_SERVER'] then
-        config.vm.provision "shell",
-            args: [ENV['APT_CACHE_SERVER']],
-            path: "cookbook/system-config/apt-cacher.sh"
-    end
+#    if ENV['APT_CACHE_SERVER'] then
+#        config.vm.provision "shell",
+#            args: [ENV['APT_CACHE_SERVER']],
+#            path: "cookbook/system-config/apt-cacher.sh"
+#    end
 
     # Make sure we have a fresh list from the package server
     config.vm.provision "shell", inline: "apt-get update"

--- a/servicetest/testframework/testhelper.py
+++ b/servicetest/testframework/testhelper.py
@@ -155,7 +155,10 @@ class EnvironmentHelper(Helper):
     # Below methods are executed on the host (in the tests)
     def env_var(self, name):
         all_vars = self.__all_env_vars(self._base_path)
-        return all_vars[name]
+        if name in all_vars:
+            return all_vars[name]
+        else:
+            return None
 
     # Private methods - helpers etc.
     def __all_env_vars(self, base_path):


### PR DESCRIPTION
The service test is skipped since it is currently not
supposed to pass, it's there to pinpoint the issue.

Also modified the testframework environment helper so
tests can compare to None when asserting non-existing
env vars.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>