### PR TITLE
DeviceNodeGateway: Remove create device support

### DIFF
--- a/doc/chapters/gateways/10-device-node-gateway.rst
+++ b/doc/chapters/gateways/10-device-node-gateway.rst
@@ -15,8 +15,6 @@ The configuration consists of a root list consisting of individual devices. Each
 following fields:
 
 - ``name`` The name of the device, with or without path. This is passed verbatim to ``mknod``
-- ``major`` The major device number, as an integer, passed verbatim to ``mknod``
-- ``minor`` The minor device number, as an integer, passed verbatim to ``mknod``
 - ``mode`` Permission mode, passed verbatim to ``chmod``
 
 In the case where the same device node is configured more than once, the most permissive mode
@@ -32,31 +30,15 @@ An example configuration can look like this::
             "name":  "/dev/dri/card0"
         },
         {
-            "name":  "tty0",
-            "major": 4,
-            "minor": 0,
-            "mode":  "644"
-        },
-        {
-            "name":  "tty1",
-            "major": 4,
-            "minor": 0,
-            "mode":  "400"
-        },
-        {
             "name":  "/dev/galcore",
-            "major": 199,
-            "minor": 0,
             "mode":  "722"
         },
         {
             "name":  "/dev/galcore",
-            "major": 199,
-            "minor": 0,
-            "mode":  "466"
+            "mode":  "600"
         }
     ]
 
-In the last example shown above the mode for ``/dev/galcore`` will be set to 766.
+In the last example shown above the mode for ``/dev/galcore`` will be set to 600.
 
 

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -757,7 +757,7 @@ bool Container::remountReadOnlyInContainer(const std::string &path)
 bool Container::mountDevice(const std::string &pathInHost)
 {
     if(!ensureContainerRunning()) {
-        log_error() << "Container is not running or in bad state, can't mount device";
+        log_error() << "Container is not running or in bad state, can't mount device: " << pathInHost;
         return false;
     }
     log_debug() << "Mounting device in container : " << pathInHost;

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodegateway.h
@@ -32,8 +32,7 @@ namespace softwarecontainer {
  * @brief This gateway is responsible for exposing device nodes in an LXC container.
  * The basic operation looks as follows:
  * - DeviceNodeGateway (DNG) is loaded with a JSON configuration detailing a
- *   list of devices to create, with device names (mandatory), permission modes (optional),
- *   major  (optional) and minor numbers  (optional).
+ *   list of devices to create, with device names (mandatory) and permission modes (optional)
  *
  * Notes:
  * - activate() will stop creating devices in the container upon first failure

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.cpp
@@ -38,12 +38,7 @@ bool DeviceNodeLogic::updateDeviceList(DeviceNodeParser::Device dev)
     if (item == std::end(m_devList)) {
         m_devList.push_back(dev);
     } else {
-        if ((item->major == dev.major) && (item->major == dev.minor)) {
-            item->mode = calculateDeviceMode(item->mode, dev.mode);
-        } else {
-            //Unexpected behavior : a device has found with same name.
-            return false;
-        }
+        item->mode = calculateDeviceMode(item->mode, dev.mode);
     }
 
     return true;

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.h
@@ -55,7 +55,6 @@ public:
     /*
      * @brief Update the device node list due to white-listing policy
      * i.e. if the device name does not exist new device node will be added
-     *      if the device name exist and major and minor minor device IDs are also matched
      *      then update the  mode of device node
      *
      * @return either true or false due to state of operation

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.cpp
@@ -30,27 +30,16 @@ bool DeviceNodeParser::parseDeviceNodeGatewayConfiguration(const json_t *element
         return false;
     }
 
-    result.major = -1;
-    result.minor = -1;
     result.mode = -1;
-    const bool majorSpecified = JSONParser::read(element, "major", result.major);
-    const bool minorSpecified = JSONParser::read(element, "minor", result.minor);
-    const bool modeSpecified = JSONParser::read(element, "mode",  result.mode);
 
-    if (majorSpecified | minorSpecified) {
-        return checkBoolSet(majorSpecified, "Major has to be specified when Minor is specified")
-            && checkBoolSet(minorSpecified, "Minor has to be specified when Major is specified")
-            && checkBoolSet(modeSpecified, "Mode has to be specified when "
-                            "Major and Minor are specified");
-    }
-    return true;
-}
+    // Mode is optional, i.e. do not do anything if it is not specified.
+    if (nullptr != json_object_get(element, "mode")) {
+        const bool modeParses = JSONParser::read(element, "mode", result.mode);
 
-bool DeviceNodeParser::checkBoolSet(const bool &value, std::string errorMessage)
-{
-    if (!value) {
-        log_error() << errorMessage;
-        return false;
+        if (!modeParses) {
+            log_error() << "Mode specified with bad format";
+            return false;
+        }
     }
 
     return true;

--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.h
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodeparser.h
@@ -32,8 +32,6 @@ public:
     struct Device
     {
         std::string name;
-        int major;
-        int minor;
         int mode;
     };
 

--- a/libsoftwarecontainer/unit-test/devicenodelogic_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodelogic_unittest.cpp
@@ -84,7 +84,7 @@ public:
  * Verify updateDeviceList and findDeviceByName functions working as expected
  */
 TEST_F(DeviceModeLogicFunctionsTests, findDeviceByNameFunction) {
-    DeviceNodeParser::Device testDevice{"testDevice", 3, 5, 753};
+    DeviceNodeParser::Device testDevice{"testDevice", 753};
     ASSERT_TRUE(dnl->updateDeviceList(testDevice));
 
     testDevice.name = "anotherTestDevice";
@@ -115,22 +115,7 @@ public:
  * This data is fed to the DeviceMode tests
  */
 INSTANTIATE_TEST_CASE_P(DeviceParameters, UpdateDeviceListFailureTests, ::testing::Values(
-        DeviceNodeParser::Device{"testDevice", 4, 5, 777},
-        DeviceNodeParser::Device{"testDevice", 3, 46, 666},
-        DeviceNodeParser::Device{"testDevice", 4, 712, 555}
+        DeviceNodeParser::Device{"testDevice", 777},
+        DeviceNodeParser::Device{"testDevice", 666},
+        DeviceNodeParser::Device{"testDevice", 555}
 ));
-
-/*
- * Verify updateDeviceList function is failing as expected when user tries to add
- * another device with same name but different major ID
- */
-TEST_P(UpdateDeviceListFailureTests, failureMismatchingDevice) {
-    DeviceNodeParser::Device testDevice{"testDevice", 3, 5, 753};
-    ASSERT_TRUE(dnl->updateDeviceList(testDevice));
-
-    testDevice.name  = testparams.name;
-    testDevice.major = testparams.major;
-    testDevice.minor = testparams.minor;
-    testDevice.mode  = testparams.mode;
-    ASSERT_FALSE(dnl->updateDeviceList(testDevice));
-}

--- a/libsoftwarecontainer/unit-test/devicenodeparser_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodeparser_unittest.cpp
@@ -39,8 +39,6 @@ TEST_F(DeviceNodeParserTest, TestConfigJustName) {
 
     ASSERT_TRUE(parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
     ASSERT_FALSE(dev.name.empty());
-    ASSERT_EQ(dev.major, -1);
-    ASSERT_EQ(dev.minor, -1);
     ASSERT_EQ(dev.mode, -1);
 }
 
@@ -50,8 +48,6 @@ TEST_F(DeviceNodeParserTest, TestConfigJustName) {
 TEST_F(DeviceNodeParserTest, TestFullConfig) {
     const std::string config1 = "{\
                                     \"name\":  \"/dev/new_device\",\
-                                    \"major\": 1,\
-                                    \"minor\": 0,\
                                     \"mode\":  644\
                                 }";
     json_t *configJSON1 = convertToJSON(config1);
@@ -59,8 +55,6 @@ TEST_F(DeviceNodeParserTest, TestFullConfig) {
 
     const std::string config2 = "{\
                                     \"name\":  \"/dev/new_device\",\
-                                    \"major\": 1,\
-                                    \"minor\": 0,\
                                     \"mode\":  764\
                                 }";
 
@@ -69,20 +63,16 @@ TEST_F(DeviceNodeParserTest, TestFullConfig) {
     json_t *configJSON2 = convertToJSON(config2);
     ASSERT_TRUE(parser.parseDeviceNodeGatewayConfiguration(configJSON2, dev));
     ASSERT_FALSE(dev.name.empty());
-    ASSERT_NE(dev.major, -1);
-    ASSERT_NE(dev.minor, -1);
     ASSERT_NE(dev.mode, -1);
     ASSERT_EQ(dev.mode, 764);
 }
 
 /*
- * Test that setting major/minor/mode fails if name is missing
+ * Test that setting mode fails if name is missing
  */
 TEST_F(DeviceNodeParserTest, TestConfigNoName) {
-    const std::string config = "{ \"major\": 2,\
-                                  \"minor\": 0,\
-                                  \"mode\": 644\
-                                }";
+    const std::string config = "{ \"mode\": 644 }";
+
     json_t *configJSON = convertToJSON(config);
     DeviceNodeParser::Device dev;
 
@@ -91,89 +81,10 @@ TEST_F(DeviceNodeParserTest, TestConfigNoName) {
 }
 
 /*
- * Test that setting minor/mode fails of major is missing
- */
-TEST_F(DeviceNodeParserTest, TestConfigNoMajor) {
-    const std::string config = "{ \"name\": \"TEST_DEVICE\", \
-                                  \"minor\": 0,\
-                                  \"mode\": 644\
-                                }";
-    json_t *configJSON = convertToJSON(config);
-    DeviceNodeParser::Device dev;
-
-    ASSERT_FALSE(parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
-    ASSERT_EQ(dev.major, -1);
-}
-
-/*
- * Test that setting major/mode fails if minor is missing
- */
-TEST_F(DeviceNodeParserTest, TestConfigNoMinor) {
-    const std::string config = "{ \"name\": \"TEST_DEVICE\", \
-                                  \"major\": 0,\
-                                  \"mode\": 644\
-                                }";
-    json_t *configJSON = convertToJSON(config);
-    DeviceNodeParser::Device dev;
-
-    ASSERT_FALSE(parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
-    ASSERT_EQ(dev.minor, -1);
-}
-
-/*
- * Test that setting major/minor fails if no mode is set.
- */
-TEST_F(DeviceNodeParserTest, TestConfigNoMode) {
-    const std::string config = "{ \"name\": \"TEST_DEVICE\", \
-                                  \"major\": 0,\
-                                  \"minor\": 6\
-                                }";
-    json_t *configJSON = convertToJSON(config);
-    DeviceNodeParser::Device dev;
-
-    ASSERT_FALSE(parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
-    ASSERT_EQ(dev.mode, -1);
-}
-
-/*
- * Test that setting major of bad type fails
- */
-TEST_F(DeviceNodeParserTest, TestConfigBadMajor) {
-    const std::string config = "{ \"name\": \"TEST_DEVICE\", \
-                                  \"major\": \"A\",\
-                                  \"minor\": 6,\
-                                  \"mode\": 644\
-                                }";
-    json_t *configJSON = convertToJSON(config);
-    DeviceNodeParser::Device dev;
-
-    ASSERT_FALSE(parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
-    ASSERT_EQ(dev.major, -1);
-}
-
-/*
- * Test that setting minor of bad type fails
- */
-TEST_F(DeviceNodeParserTest, TestConfigBadMainor) {
-    const std::string config = "{ \"name\": \"TEST_DEVICE\", \
-                                  \"major\": 2,\
-                                  \"minor\": \"B\",\
-                                  \"mode\": 644\
-                                }";
-    json_t *configJSON = convertToJSON(config);
-    DeviceNodeParser::Device dev;
-
-    ASSERT_FALSE(parser.parseDeviceNodeGatewayConfiguration(configJSON, dev));
-    ASSERT_EQ(dev.minor, -1);
-}
-
-/*
  * Test that setting mode of bad type fails
  */
 TEST_F(DeviceNodeParserTest, TestConfigBadMode) {
     const std::string config = "{ \"name\": \"TEST_DEVICE\", \
-                                  \"major\": 2,\
-                                  \"minor\": 6,\
                                   \"mode\": \"C\"\
                                 }";
     json_t *configJSON = convertToJSON(config);


### PR DESCRIPTION
Remove support for creating new devices in the container via the
DeviceNodeGateway. Creating new devices is hard to fit into the
whitelisting strategy and creates more problems than it solves. As a
result of this change there is no longer any need specifying major
minor versions of the device in the config.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>