### PR TITLE
Fixed issue with leaking GW configs

### DIFF
--- a/agent/src/capability/baseconfigstore.cpp
+++ b/agent/src/capability/baseconfigstore.cpp
@@ -105,6 +105,7 @@ void BaseConfigStore::readCapsFromFile(const std::string &filePath)
     }
 
     // Can't use json_decref on fileroot, it removes objects too early
+    // TODO: So when do we actually do decref on this?
     parseCapabilities(capabilities);
 }
 
@@ -142,7 +143,7 @@ void BaseConfigStore::parseCapabilities(json_t *capabilities)
             throw CapabilityParseError(errorMessage);
         }
 
-        log_debug() << "Found capability \"" << capName << "\", parsing gateways...";
+        log_debug() << "Found capability \"" << capName << "\"";
 
         parseGatewayConfigs(capName, gateways);
     }

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -305,6 +305,13 @@ void SoftwareContainerAgent::setCapabilities(const ContainerID &containerID,
         return;
     }
 
+    // Log a list of all caps that were provided
+    std::string caps = "";
+    for (const std::string &capName : capabilities) {
+        caps += " " + capName;
+    }
+    log_debug() << "Will attempt to set capabilities:" + caps;
+
     GatewayConfiguration gatewayConfigs = m_defaultConfigStore->configs();
     GatewayConfiguration filteredConfigs = m_filteredConfigStore->configsByID(capabilities);
 

--- a/common/gatewayconfig.cpp
+++ b/common/gatewayconfig.cpp
@@ -32,6 +32,17 @@ GatewayConfiguration::GatewayConfiguration(const GatewayConfiguration &gwConf)
     }
 }
 
+GatewayConfiguration& GatewayConfiguration::operator=(const GatewayConfiguration &gwConf)
+{
+    // We need to indicate our intention to use the json data later by incref-ing it
+    m_configMap = gwConf.m_configMap;
+    for (auto item : m_configMap) {
+        json_incref(item.second);
+    }
+
+    return *this;
+}
+
 GatewayConfiguration::~GatewayConfiguration()
 {
     for (auto &it : m_configMap) {
@@ -77,8 +88,8 @@ bool GatewayConfiguration::append(const std::string &id, json_t *sourceArray)
         }
         json_decref(backupArray);
     } else {
-        m_configMap[id] = sourceArray;
-        json_incref(sourceArray);
+        m_configMap[id] = json_deep_copy(sourceArray);
+        // we do not need to decref the sourceArray since we did a deep copy
     }
 
     return true;

--- a/common/gatewayconfig.h
+++ b/common/gatewayconfig.h
@@ -39,6 +39,8 @@ public:
 
     GatewayConfiguration(const GatewayConfiguration &gwConf);
 
+    GatewayConfiguration& operator=(const GatewayConfiguration &gwConf);
+
     ~GatewayConfiguration();
 
     bool append(const std::string &id, const std::string &jsonConf);

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -214,6 +214,7 @@ bool SoftwareContainer::configureGateways(const GatewayConfiguration &gwConfig)
         json_t *config = gwConfig.config(gatewayId);
         if (config != nullptr) {
             log_debug() << "Configuring gateway: " << gatewayId;
+            log_debug() << json_dumps(config, JSON_INDENT(4));
             try {
                 if (!gateway->setConfig(config)) {
                     log_error() << "Failed to apply gateway configuration";

--- a/servicetest/environment/test_environment.py
+++ b/servicetest/environment/test_environment.py
@@ -238,7 +238,6 @@ class TestCapsBehaviorMultipleContainers(object):
         behavior.
     """
 
-    @pytest.mark.skip()
     def test_caps_for_one_container_does_not_affect_another_container(self):
         """ Test that setting caps for one containers does not have an impact
             on another container.


### PR DESCRIPTION
The problem with GW configs leaking between caps
when using multiple containers is fixed. Relevant
service test is enabled again. Some additional
debug outpuut added as well.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>