### PR TITLE
Agent: add checks that DBus setup works properly

### DIFF
--- a/agent/src/dbus/softwarecontaineragent_dbus_stub.cpp
+++ b/agent/src/dbus/softwarecontaineragent_dbus_stub.cpp
@@ -62,27 +62,34 @@ Glib::ustring interfaceXml0 = R"XML_DELIMITER(
 </node>
 )XML_DELIMITER";
 
-com::pelagicore::SoftwareContainerAgent::SoftwareContainerAgent() : connectionId(0), registeredId(0), m_objectPath("/com/pelagicore/SoftwareContainerAgent"), m_interfaceName("com.pelagicore.SoftwareContainerAgent") {
-
-    ProcessStateChanged_signal.connect(sigc::mem_fun(this, &SoftwareContainerAgent::ProcessStateChanged_emitter));
-
+com::pelagicore::SoftwareContainerAgent::SoftwareContainerAgent() :
+    connectionId(0),
+    registeredId(0),
+    m_objectPath("/com/pelagicore/SoftwareContainerAgent"),
+    m_interfaceName("com.pelagicore.SoftwareContainerAgent")
+{
+    ProcessStateChanged_signal.connect(
+        sigc::mem_fun(this, &SoftwareContainerAgent::ProcessStateChanged_emitter)
+    );
 }
-void com::pelagicore::SoftwareContainerAgent::connect (
+
+void com::pelagicore::SoftwareContainerAgent::connect(
     Gio::DBus::BusType busType,
     std::string name)
 {
     try {
-            introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
+        introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
-            g_warning("Unable to create introspection data: ");
-            g_warning(std::string(ex.what()).c_str());
-            g_warning("\n");
+        g_warning("Unable to create introspection data: %s \n", ex.what().c_str());
     }
-    connectionId = Gio::DBus::own_name(busType,
-                                       name,
-                                       sigc::mem_fun(this, &SoftwareContainerAgent::on_bus_acquired),
-                                       sigc::mem_fun(this, &SoftwareContainerAgent::on_name_acquired),
-                                       sigc::mem_fun(this, &SoftwareContainerAgent::on_name_lost));
+
+    connectionId = Gio::DBus::own_name(
+        busType,
+        name,
+        sigc::mem_fun(this, &SoftwareContainerAgent::on_bus_acquired),
+        sigc::mem_fun(this, &SoftwareContainerAgent::on_name_acquired),
+        sigc::mem_fun(this, &SoftwareContainerAgent::on_name_lost)
+    );
 }
 
 void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
@@ -98,6 +105,7 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
             List(
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("Create") == 0) {
             Glib::Variant<Glib::ustring > base_config;
             parameters.get_child(base_config, 0);
@@ -108,6 +116,7 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
                 Glib::ustring(p_config),
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("Execute") == 0) {
             Glib::Variant<gint32 > base_containerID;
             parameters.get_child(base_containerID, 0);
@@ -142,6 +151,7 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
                 SoftwareContainerAgentCommon::glibStringMapToStdStringMap(p_env),
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("Suspend") == 0) {
             Glib::Variant<gint32 > base_containerID;
             parameters.get_child(base_containerID, 0);
@@ -152,6 +162,7 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
                 (p_containerID),
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("Resume") == 0) {
             Glib::Variant<gint32 > base_containerID;
             parameters.get_child(base_containerID, 0);
@@ -162,6 +173,7 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
                 (p_containerID),
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("Destroy") == 0) {
             Glib::Variant<gint32 > base_containerID;
             parameters.get_child(base_containerID, 0);
@@ -172,6 +184,7 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
                 (p_containerID),
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("BindMount") == 0) {
             Glib::Variant<gint32 > base_containerID;
             parameters.get_child(base_containerID, 0);
@@ -200,10 +213,12 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
                 (p_readOnly),
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("ListCapabilities") == 0) {
             ListCapabilities(
                 SoftwareContainerAgentMessageHelper(invocation));
         }
+
         if (method_name.compare("SetCapabilities") == 0) {
             Glib::Variant<gint32 > base_containerID;
             parameters.get_child(base_containerID, 0);
@@ -227,51 +242,51 @@ void com::pelagicore::SoftwareContainerAgent::on_method_call(const Glib::RefPtr<
     }
 }
 
-void com::pelagicore::SoftwareContainerAgent::on_interface_get_property(Glib::VariantBase& property,
-                      const Glib::RefPtr<Gio::DBus::Connection>& connection,
-                      const Glib::ustring& sender,
-                      const Glib::ustring& object_path,
-                      const Glib::ustring& interface_name,
-                      const Glib::ustring& property_name) {
-
+void com::pelagicore::SoftwareContainerAgent::on_interface_get_property(
+    Glib::VariantBase& /* property */,
+    const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+    const Glib::ustring& /* sender */,
+    const Glib::ustring& /* object_path */,
+    const Glib::ustring& /* interface_name */,
+    const Glib::ustring& /* property_name */)
+{
 }
 
 bool com::pelagicore::SoftwareContainerAgent::on_interface_set_property(
-       const Glib::RefPtr<Gio::DBus::Connection>& connection,
-       const Glib::ustring& sender,
-       const Glib::ustring& object_path,
-       const Glib::ustring& interface_name,
-       const Glib::ustring& property_name,
-       const Glib::VariantBase& value) {
-
-
+    const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+    const Glib::ustring& /* sender */,
+    const Glib::ustring& /* object_path */,
+    const Glib::ustring& /* interface_name */,
+    const Glib::ustring& /* property_name */,
+    const Glib::VariantBase& /* value */)
+{
     return true;
 }
 
-void com::pelagicore::SoftwareContainerAgent::ProcessStateChanged_emitter(gint32 containerID, guint32 processID, bool isRunning, guint32 exitCode) {
-            std::vector<Glib::VariantBase> paramsList;
+void com::pelagicore::SoftwareContainerAgent::ProcessStateChanged_emitter(
+    gint32 containerID,
+    guint32 processID,
+    bool isRunning,
+    guint32 exitCode)
+{
+    std::vector<Glib::VariantBase> paramsList;
+    paramsList.push_back(Glib::Variant<gint32 >::create((containerID)));;
+    paramsList.push_back(Glib::Variant<guint32 >::create((processID)));;
+    paramsList.push_back(Glib::Variant<bool >::create((isRunning)));;
+    paramsList.push_back(Glib::Variant<guint32 >::create((exitCode)));;
 
-paramsList.push_back(Glib::Variant<gint32 >::create((containerID)));;
+    m_connection->emit_signal(
+        "/com/pelagicore/SoftwareContainerAgent",
+        "com.pelagicore.SoftwareContainerAgent",
+        "ProcessStateChanged",
+        Glib::ustring(),
+        Glib::Variant<std::vector<Glib::VariantBase> >::create_tuple(paramsList));
+}
 
-
-paramsList.push_back(Glib::Variant<guint32 >::create((processID)));;
-
-
-paramsList.push_back(Glib::Variant<bool >::create((isRunning)));;
-
-
-paramsList.push_back(Glib::Variant<guint32 >::create((exitCode)));;
-
-m_connection->emit_signal(
-              "/com/pelagicore/SoftwareContainerAgent",
-              "com.pelagicore.SoftwareContainerAgent",
-              "ProcessStateChanged",
-              Glib::ustring(),
-              Glib::Variant<std::vector<Glib::VariantBase> >::create_tuple(paramsList));
-      }
-
-void com::pelagicore::SoftwareContainerAgent::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection>& connection,
-                         const Glib::ustring& /* name */) {
+void com::pelagicore::SoftwareContainerAgent::on_bus_acquired(
+    const Glib::RefPtr<Gio::DBus::Connection>& connection,
+    const Glib::ustring& /* name */)
+{
     Gio::DBus::InterfaceVTable *interface_vtable =
           new Gio::DBus::InterfaceVTable(
                 sigc::mem_fun(this, &SoftwareContainerAgent::on_method_call),
@@ -282,19 +297,29 @@ void com::pelagicore::SoftwareContainerAgent::on_bus_acquired(const Glib::RefPtr
             introspection_data->lookup_interface("com.pelagicore.SoftwareContainerAgent"),
             *interface_vtable);
         m_connection = connection;
+    } catch(const Glib::Error& ex) {
+        object_not_registered.emit("Registration of object failed");
     }
-    catch(const Glib::Error& ex) {
-        g_warning("Registration of object failed");
-    }
-
-    return;
 }
-void com::pelagicore::SoftwareContainerAgent::on_name_acquired(const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
-                      const Glib::ustring& /* name */) {}
 
-void com::pelagicore::SoftwareContainerAgent::on_name_lost(const Glib::RefPtr<Gio::DBus::Connection>& connection,
-                  const Glib::ustring& /* name */) {}
+void com::pelagicore::SoftwareContainerAgent::on_name_acquired(
+    const Glib::RefPtr<Gio::DBus::Connection>& /* connection */,
+    const Glib::ustring &name)
+{
+    name_acquired.emit(name);
+}
 
+void com::pelagicore::SoftwareContainerAgent::on_name_lost(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    const Glib::ustring &name)
+{
+    if (!connection) {
+        name_lost.emit("Unable to connect to the bus (is a bus running?)");
+    } else {
+        name_lost.emit("Unable to acquire the name " 
+                      + name + " on the bus (is another agent running?)");
+    }
+}
 
 bool com::pelagicore::SoftwareContainerAgent::emitSignal(const std::string& propName, Glib::VariantBase& value) {
     std::map<Glib::ustring, Glib::VariantBase> changedProps;

--- a/agent/src/dbus/softwarecontaineragent_dbus_stub.h
+++ b/agent/src/dbus/softwarecontaineragent_dbus_stub.h
@@ -11,9 +11,10 @@ namespace pelagicore {
 class SoftwareContainerAgent {
 public:
     SoftwareContainerAgent ();
-    void connect (Gio::DBus::BusType, std::string);
 
 protected:
+    void connect (Gio::DBus::BusType, std::string);
+
     virtual void List (
         const SoftwareContainerAgentMessageHelper msg) = 0;
 
@@ -91,14 +92,23 @@ protected:
            const Glib::ustring& property_name,
            const Glib::VariantBase& value);
 
-private:
-bool emitSignal(const std::string& propName, Glib::VariantBase& value);
+    /*
+     * We emit these signals when we have a lost/acquired a name on dbus,
+     * so that subclasses of this class can bind slots to these signals.
+     */
+    sigc::signal<void, std::string> name_lost;
+    sigc::signal<void, std::string> name_acquired;
+    sigc::signal<void, std::string> object_not_registered;
 
-guint connectionId, registeredId;
-Glib::RefPtr<Gio::DBus::NodeInfo> introspection_data;
-Glib::RefPtr<Gio::DBus::Connection> m_connection;
-std::string m_objectPath;
-std::string m_interfaceName;
+private:
+    bool emitSignal(const std::string& propName, Glib::VariantBase& value);
+
+    guint connectionId;
+    guint registeredId;
+    Glib::RefPtr<Gio::DBus::NodeInfo> introspection_data;
+    Glib::RefPtr<Gio::DBus::Connection> m_connection;
+    std::string m_objectPath;
+    std::string m_interfaceName;
 };
 }// pelagicore
 }// com

--- a/agent/src/dbus/softwarecontaineragentadaptor.h
+++ b/agent/src/dbus/softwarecontaineragentadaptor.h
@@ -32,7 +32,10 @@ class SoftwareContainerAgentAdaptor :
 public:
     virtual ~SoftwareContainerAgentAdaptor();
 
-    SoftwareContainerAgentAdaptor(::softwarecontainer::SoftwareContainerAgent &agent, bool useSessionBus);
+    SoftwareContainerAgentAdaptor(
+        Glib::RefPtr<Glib::MainLoop> &mainLoop,
+        ::softwarecontainer::SoftwareContainerAgent &agent,
+        bool useSessionBus);
 
     void List(SoftwareContainerAgentMessageHelper msg) override;
     void ListCapabilities(SoftwareContainerAgentMessageHelper msg) override;
@@ -62,6 +65,12 @@ public:
 
     void Create(const std::string config, SoftwareContainerAgentMessageHelper msg) override;
 
+private:
+    // Slots to be invoked to notify on error or success in dbus setup
+    void onDBusError(std::string message);
+    void onDBusNameAcquired(std::string message);
+
+    Glib::RefPtr<Glib::MainLoop> m_mainLoop;
     ::softwarecontainer::SoftwareContainerAgent &m_agent;
 
 };

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -216,11 +216,17 @@ int main(int argc, char **argv)
         std::shared_ptr<Config> config = std::make_shared<Config>(std::move(configSources),
                                                                   ConfigDefinition::mandatory(),
                                                                   ConfigDependencies());
-        std::shared_ptr<SoftwareContainerFactory> factory = std::shared_ptr<SoftwareContainerFactory> (new SoftwareContainerFactory());
-        std::shared_ptr<ContainerUtilityInterface> utility = std::shared_ptr<ContainerUtilityInterface> (new ContainerUtilityInterface());
+        std::shared_ptr<SoftwareContainerFactory> factory =
+            std::shared_ptr<SoftwareContainerFactory> (new SoftwareContainerFactory());
+        std::shared_ptr<ContainerUtilityInterface> utility =
+            std::shared_ptr<ContainerUtilityInterface> (new ContainerUtilityInterface());
 
         ::softwarecontainer::SoftwareContainerAgent agent(mainContext, config, factory, utility);
-        std::unique_ptr<SoftwareContainerAgentAdaptor> adaptor(new SoftwareContainerAgentAdaptor(agent, useSessionBus));
+        std::unique_ptr<SoftwareContainerAgentAdaptor> adaptor(
+            // The adaptor needs access to the mainloop in order to be able to exit the 
+            // loop in case dbus setup fails.
+            new SoftwareContainerAgentAdaptor(ml, agent, useSessionBus)
+        );
 
         // Register UNIX signal handler
         g_unix_signal_add(SIGINT, &signalHandler, &ml);

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -221,7 +221,15 @@ int main(int argc, char **argv)
         std::shared_ptr<ContainerUtilityInterface> utility =
             std::shared_ptr<ContainerUtilityInterface> (new ContainerUtilityInterface());
 
+        // Create the actual agent
         ::softwarecontainer::SoftwareContainerAgent agent(mainContext, config, factory, utility);
+
+        // We may have had a value for this in the config, so we need to check it, to know
+        // what bus we want to connect to on D-Bus.
+        useSessionBus = config->getBoolValue(ConfigDefinition::SC_GROUP,
+                                             ConfigDefinition::SC_USE_SESSION_BUS_KEY);
+
+        // Create the agent adaptor, that connects the agent to D-Bus.
         std::unique_ptr<SoftwareContainerAgentAdaptor> adaptor(
             // The adaptor needs access to the mainloop in order to be able to exit the 
             // loop in case dbus setup fails.

--- a/servicetest/agent/test_agent.py
+++ b/servicetest/agent/test_agent.py
@@ -22,7 +22,9 @@ import os
 import time
 # import lxc
 
-from testframework import Container, SoftwareContainerAgentHandler
+from testframework import Container
+from testframework import SoftwareContainerAgentHandler
+from testframework import ConfigFile
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -53,6 +55,28 @@ DATA = {
 
 ### Test suites ###
 
+@pytest.mark.usefixtures("create_testoutput_dir", "assert_no_session_bus", "agent_without_checks")
+class TestNoSessionBus(object):
+    """ This test suite tests that SC properly fails to connect
+        to the session bus when there is no such bus
+    """
+
+    @staticmethod
+    def agent_config():
+        """ The agent fixture calls this function when it creates the config file to be
+            used in this class. It expects a ConfigFile object.
+        """
+        return ConfigFile(TESTOUTPUT_DIR + "/agent-config",
+                {
+                    "SoftwareContainer": {"use-session-bus": "true"}
+                }
+        )
+
+    def test_session_bus_fails(self, agent_without_checks):
+        """ The agent should fail directly, given the above config file
+        """
+        time.sleep(0.5)
+        assert not agent_without_checks.is_alive()
 
 @pytest.mark.usefixtures("create_testoutput_dir", "agent")
 class TestClearOldContainers(object):

--- a/servicetest/capabilities/test_caps.py
+++ b/servicetest/capabilities/test_caps.py
@@ -26,7 +26,6 @@ from testframework import Container
 from testframework import Capability
 from testframework import StandardManifest
 from testframework import DefaultManifest
-from testframework import ConfigFile
 
 from dbus.exceptions import DBusException
 
@@ -119,16 +118,6 @@ def service_manifests():
 def mounted_path_in_host():
     return CURRENT_DIR
 
-def agent_config():
-    """ The agent fixture calls this function when it creates the config file to be
-        used in this module. It expects a ConfigFile object.
-    """
-    return ConfigFile(TESTOUTPUT_DIR + "/agent-config",
-            {
-                "SoftwareContainer": {"use-session-bus": "true"}
-            }
-    )
-
 @pytest.mark.usefixtures("testhelper", "dbus_launch", "create_testoutput_dir", "agent", "assert_no_proxy")
 class TestCaps(object):
     """ This suite tests that capabilities can be used with SoftwareContainer with
@@ -142,6 +131,7 @@ class TestCaps(object):
         more specific test suites, but rather to make sure the capabilities result
         in the correct gateway configs being applied.
     """
+
 
     def test_set_caps_with_empty_arg_is_allowed(self):
         """ Test that there is no error when passing an empty list of caps, i.e. no caps


### PR DESCRIPTION
Makes sure that we can connect to the bus, and that we can
own the softwarecontainer name on that bus. In case of error,
the agent quits.

Also some cleanup in the generated code.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>