### PR TITLE
cmake: fix git revision checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,6 @@ set(${PROJECT_NAME}_PATCH_LEVEL 0)
 set(VERSION ${${PROJECT_NAME}_MAJOR_VERSION}.${${PROJECT_NAME}_MINOR_VERSION}.${${PROJECT_NAME}_PATCH_LEVEL})
 add_definitions(-DPACKAGE_VERSION="${VERSION}")
 
-execute_process(COMMAND "/usr/bin/git" "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE REVISION_RAW)
-
-string(REPLACE "\n" "" REVISION "${REVISION_RAW}")
-string(TIMESTAMP DATE "%Y-%m-%d")
-
 #
 # Find dependencies, and include them etc
 #

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,6 +23,16 @@ cmake_minimum_required(VERSION 3.0.2)
 #
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
 
+find_program(git_binary git)
+if(git_binary)
+    execute_process(COMMAND ${git_binary} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE REVISION_RAW)
+    string(REPLACE "\n" "" REVISION "${REVISION_RAW}")
+else()
+    set(REVISION "unknown")
+endif()
+
+string(TIMESTAMP DATE "%Y-%m-%d")
+
 add_custom_target(doc ALL)
 
 if(ENABLE_USER_DOC)


### PR DESCRIPTION
git might not be /usr/bin/git, and we should give some kind of output
even if the git binary is not found.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>