### PR TITLE
filetoolkit: Remove createSymLink.

### DIFF
--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -279,25 +279,4 @@ void FileToolkitWithUndo::markFileForDeletion(const std::string &path)
     }
 }
 
-bool FileToolkitWithUndo::createSymLink(const std::string &source,
-                                        const std::string &destination)
-{
-    log_debug() << "creating symlink " << source << " pointing to " << destination;
-
-    createDirectory(parentPath(source));
-
-    if (symlink(destination.c_str(), source.c_str()) == 0) {
-        if (!pathInList(source)) {
-            m_cleanupHandlers.push_back(new FileCleanUpHandler(source));
-        }
-        log_debug() << "Successfully created symlink from " << source << " to " << destination;
-    } else {
-        log_error() << "Error creating symlink " << destination
-                    << " pointing to " << source << ". Error: "
-                    << strerror(errno);
-        return false;
-    }
-    return true;
-}
-
 } // namespace softwarecontainer

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -55,8 +55,6 @@ public:
      */
     std::string tempDir(std::string templatePath);
 protected:
-    bool createSymLink(const std::string &source, const std::string &destination);
-
     /*
      * @brief Writes to a file (and optionally create it)
      */

--- a/libsoftwarecontainer/src/container.h
+++ b/libsoftwarecontainer/src/container.h
@@ -154,11 +154,6 @@ public:
 
     bool mountDevice(const std::string &pathInHost);
 
-    bool createSymLink(const std::string &source, const std::string &destination)
-    {
-        return FileToolkitWithUndo::createSymLink(source, destination);
-    }
-
     /**
      * @brief Calls shutdown, and then destroys the container
      */

--- a/libsoftwarecontainer/src/containerabstractinterface.h
+++ b/libsoftwarecontainer/src/containerabstractinterface.h
@@ -49,7 +49,6 @@ public:
     virtual bool destroy(unsigned int timeout) = 0;
 
     virtual bool mountDevice(const std::string &pathInHost) = 0;
-    virtual bool createSymLink(const std::string &source, const std::string &destination) = 0;
 
     /**
      * @brief Tries to bind mount a path from host to container

--- a/libsoftwarecontainer/unit-test/devicenode_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenode_unittest.cpp
@@ -112,7 +112,6 @@ public :
     bool destroy(unsigned int) {return true;}
 
     bool mountDevice(const std::string &) {return true;}
-    bool createSymLink(const std::string &, const std::string &) {return true;}
 
     bool bindMountInContainer(const std::string &, const std::string &, bool ) {return true;}
 


### PR DESCRIPTION
The directive was used when the paths in the container were not
absolute. However, since paths are now absolute, this directive is
pointless. Thus, createSymLink is removed from filetoolkit and
containerabstractinterface.

Signed-off-by: kursat <kursat.kobya@pelagicore.com>