### PR TITLE
container: remove rootFS(), it is never used

### DIFF
--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -853,9 +853,4 @@ std::string Container::gatewaysDir() const
     return buildPath(m_containerRoot, id(), GATEWAYS_PATH);
 }
 
-const std::string &Container::rootFS() const
-{
-    return m_rootFSPath;
-}
-
 } // namespace softwarecontainer

--- a/libsoftwarecontainer/src/container.h
+++ b/libsoftwarecontainer/src/container.h
@@ -215,7 +215,6 @@ public:
     const char *id() const;
     std::string gatewaysDirInContainer() const;
     std::string gatewaysDir() const;
-    const std::string &rootFS() const;
 
     bool setEnvironmentVariable(const std::string &var, const std::string &val);
 

--- a/libsoftwarecontainer/src/containerabstractinterface.h
+++ b/libsoftwarecontainer/src/containerabstractinterface.h
@@ -32,7 +32,6 @@ public:
 
     virtual ~ContainerAbstractInterface() {};
     virtual const char *id() const = 0;
-    virtual const std::string &rootFS() const = 0;
 
     virtual bool initialize() = 0;
     virtual bool create() = 0;

--- a/libsoftwarecontainer/unit-test/devicenode_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenode_unittest.cpp
@@ -95,7 +95,6 @@ class MockContainer : public ContainerAbstractInterface
 public :
     MockContainer () {}
     const char *id() const {return "";}
-    const std::string &rootFS() const {return "";}
 
     bool initialize() {return true;}
     bool create() {return true;}


### PR DESCRIPTION
This function was previously used by at least the device node gateway,
but after work on it and other gateways that possibly used it, the
method is not used anywhere.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>