### PR TITLE
DeviceNodeGateway: Clean new operator

### DIFF
--- a/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.cpp
+++ b/libsoftwarecontainer/src/gateway/devicenode/devicenodelogic.cpp
@@ -36,7 +36,7 @@ bool DeviceNodeLogic::updateDeviceList(Device &dev)
     auto item = findDeviceByName(dev.getName());
 
     if (item == nullptr) {
-        std::shared_ptr<Device> newDevice(new Device(dev));
+        auto newDevice = std::make_shared<Device>(dev);
         m_devList.push_back(std::move(newDevice));
     } else {
         item->calculateDeviceMode(dev.getMode());

--- a/libsoftwarecontainer/unit-test/devicenodelogic_unittest.cpp
+++ b/libsoftwarecontainer/unit-test/devicenodelogic_unittest.cpp
@@ -31,12 +31,7 @@ class DeviceModeLogicFunctionsTests : public ::testing::Test
 {
 public:
     DeviceModeLogicFunctionsTests() { };
-    DeviceNodeLogic *dnl;
-
-    void SetUp() override
-    {
-        dnl = new DeviceNodeLogic();
-    }
+    DeviceNodeLogic dnl;
 };
 
 
@@ -45,14 +40,14 @@ public:
  */
 TEST_F(DeviceModeLogicFunctionsTests, findDeviceByNameFunction) {
     Device testDevice{"testDevice", 753};
-    ASSERT_TRUE(dnl->updateDeviceList(testDevice));
+    ASSERT_TRUE(dnl.updateDeviceList(testDevice));
 
     Device testDevice2{"anotherTestDevice", 444};
-    ASSERT_TRUE(dnl->updateDeviceList(testDevice2));
+    ASSERT_TRUE(dnl.updateDeviceList(testDevice2));
 
     Device testDevice3{"yetAnotherTestDevice", 751};
-    ASSERT_TRUE(dnl->updateDeviceList(testDevice3));
+    ASSERT_TRUE(dnl.updateDeviceList(testDevice3));
 
-    auto device = dnl->findDeviceByName("anotherTestDevice");
+    auto device = dnl.findDeviceByName("anotherTestDevice");
     ASSERT_EQ("anotherTestDevice", device->getName());
 }


### PR DESCRIPTION
Clean usage of new operator from DeviceNodeLogic. This way the line that adds new device will be more consise and readable.

Signed-off-by: kursat <kursat.kobya@pelagicore.com>