### PR TITLE
Fix bindmounts when using writebuffers

### DIFF
--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -127,7 +127,7 @@ bool FileToolkitWithUndo::bindMount(const std::string &src,
 
     log_debug() << "Bind-mounting " << src << " in " << dst << ", flags: " << flags;
 
-    if(enableWriteBuffer) {
+    if(enableWriteBuffer && isDirectory(src)) {
         std::string upperDir = tempDir("/tmp/sc-bindmount-upper-XXXXXX");
         std::string workDir = tempDir("/tmp/sc-bindmount-work-XXXXXX");
         fstype.assign("overlay");

--- a/doc/chapters/filesystem/index.rst
+++ b/doc/chapters/filesystem/index.rst
@@ -133,3 +133,6 @@ When the container is shutdown and the mountpoints are cleaned up, the
 upper filesystem is copied into the lower filesystem causing the filesystem
 changes performed during its runtime to be merged into the lower layers.
 
+.. Note:: Non-directory types of files can not be mounted using overlayfs. 
+These will automatically fall back on using the default behavior of bind
+mounting the files into the filesystem of the container.

--- a/servicetest/filesystem/test_filesystem.py
+++ b/servicetest/filesystem/test_filesystem.py
@@ -19,10 +19,8 @@ import pytest
 
 import os
 import time
-import subprocess
-import fileapp
-import time
 import platform
+import socket
 
 from testframework import Container
 
@@ -30,9 +28,12 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 TESTOUTPUT_DIR = CURRENT_DIR + "/testoutput"
 TESTFILE = 'testfile.txt'
 
-# This function is used by the test framework to know where test specific files should be stored
+
+# This function is used by the test framework to know where test specific
+# files should be stored
 def output_dir():
     return TESTOUTPUT_DIR
+
 
 # This function is used by the 'agent' fixture to know where the log should
 # be stored
@@ -45,6 +46,7 @@ DATA = {
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False
 }
+
 
 @pytest.mark.usefixtures("create_testoutput_dir", "dbus_launch", "agent", "assert_no_proxy")
 class TestFileSystem(object):
@@ -59,15 +61,13 @@ class TestFileSystem(object):
         Test if the write buffer flag works as expected, if the flag is enabled
         files should not be written directly to the underlying file system. If
         it is disabled, files should be written directly to the file system
-        :param flag: enable or disable writeBuffer.
-        :return: Nothing
 
         :TODO: If the system doesn't have overlayfs and enableWriteBuffer is
         enabled, this test will work anyways since we fail to mount the fs
         containing fileapp.py, hence failing to create lala.txt, and hence the
         file isn't available after running the create process.
 
-        A nice way of getting process exit value from the container would be
+        A way of getting process exit value from the container would be
         very nice.
         """
         absoluteTestFile = os.path.join(CURRENT_DIR, TESTFILE)
@@ -81,7 +81,7 @@ class TestFileSystem(object):
             DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
 
         try:
-            success = ca.start(DATA)
+            ca.start(DATA)
             ca.launch_command('{}/fileapp.py create {}'
                               .format(ca.get_bind_dir(), TESTFILE))
 
@@ -101,3 +101,104 @@ class TestFileSystem(object):
             assert os.path.exists(absoluteTestFile) is False
         finally:
             ca.terminate()
+
+    @pytest.mark.xfail("platform.release() <= \"3.18.0\"")
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_bindmount_files(self, flag):
+        """ Test that files are bindmountable as expected.
+        """
+        absoluteTestFile = os.path.join(CURRENT_DIR, TESTFILE)
+
+        if not os.path.exists(absoluteTestFile):
+            f = open(absoluteTestFile, "w")
+            f.write("gobbles")
+            f.close()
+
+        ca = Container()
+        if flag is True:
+            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+        else:
+            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+
+        try:
+            ca.start(DATA)
+            ca.bindmount(absoluteTestFile, "/gateways/testfile", True)
+            # Give the command time to run inside the container
+            time.sleep(0.5)
+            assert os.path.exists(absoluteTestFile) is True
+            ca.launch_command('{}/fileapp.py check {}'
+                              .format(ca.get_bind_dir(), "/gateways/testfile"))
+            time.sleep(0.5)
+            assert os.path.exists(absoluteTestFile) is True
+        finally:
+            ca.terminate()
+
+        if os.path.exists(absoluteTestFile):
+            os.remove(absoluteTestFile)
+
+    @pytest.mark.xfail("platform.release() <= \"3.18.0\"")
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_bindmount_fifos(self, flag):
+        """ Test that fifos are bindmountable as expected.
+        """
+        absoluteTestFile = os.path.join("/tmp/", TESTFILE)
+
+        if not os.path.exists(absoluteTestFile):
+            os.mkfifo(absoluteTestFile)
+
+        ca = Container()
+        if flag is True:
+            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+        else:
+            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+
+        try:
+            ca.start(DATA)
+            ca.bindmount(absoluteTestFile, "/gateways/testfile", True)
+            # Give the command time to run inside the container
+            time.sleep(0.5)
+            assert os.path.exists(absoluteTestFile) is True
+            ca.launch_command('{}/fileapp.py check {}'
+                              .format(ca.get_bind_dir(), "/gateways/testfile"))
+            time.sleep(0.5)
+            assert os.path.exists(absoluteTestFile) is True
+        finally:
+            ca.terminate()
+
+        if os.path.exists(absoluteTestFile):
+            os.remove(absoluteTestFile)
+
+    @pytest.mark.xfail("platform.release() <= \"3.18.0\"")
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_bindmount_sockets(self, flag):
+        """ Test that sockets are bindmountable as expected.
+        """
+        absoluteTestFile = os.path.join("/tmp/", TESTFILE)
+
+        if not os.path.exists(absoluteTestFile):
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(absoluteTestFile)
+
+        ca = Container()
+        if flag is True:
+            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+        else:
+            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+
+        try:
+            ca.start(DATA)
+            ca.bindmount(absoluteTestFile, "/gateways/testfile", True)
+            # Give the command time to run inside the container
+            time.sleep(0.5)
+            assert os.path.exists(absoluteTestFile) is True
+            ca.launch_command('{}/fileapp.py check {}'
+                              .format(ca.get_bind_dir(), "/gateways/testfile"))
+            time.sleep(0.5)
+            assert os.path.exists(absoluteTestFile) is True
+        finally:
+            ca.terminate()
+
+        server.close()
+
+        if os.path.exists(absoluteTestFile):
+            os.remove(absoluteTestFile)

--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -306,7 +306,6 @@ class Container():
                                    env)
         return pid
 
-
     def get_bind_dir(self):
         """ Returns the path containing the bind mounted dir set previously
 
@@ -345,6 +344,8 @@ class Container():
         self.__bind_dir = data[Container.BIND_MOUNT_DIR]
         return container_id
 
+    def bindmount(self, hostpath, dirname, readonly):
+        return self.__bindmount(hostpath, dirname, readonly)
 
     def suspend(self):
         if self.__container_id is not None:


### PR DESCRIPTION
The writebuffers wont work together with files, fifos and sockets. Disable
this for the future. Add service tests to make sure it works as expected in
the future

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>