### PR TITLE
Rollback on failed unmount operations

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HEADERS
     directorycleanuphandler.h
     filecleanuphandler.h
     mountcleanuphandler.h
+    createdir.h
     filetoolkitwithundo.h
     gatewayconfig.h
     signalconnectionshandler.h
@@ -37,6 +38,7 @@ add_library(softwarecontainercommon SHARED
     directorycleanuphandler.cpp
     filecleanuphandler.cpp
     jsonparser.cpp
+    createdir.cpp
     filetoolkitwithundo.cpp
     mountcleanuphandler.cpp
     overlaysynccleanuphandler.cpp

--- a/common/createdir.cpp
+++ b/common/createdir.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "createdir.h"
+#include "softwarecontainererror.h"
+
 #include <sys/stat.h>
 
 namespace softwarecontainer {
@@ -91,8 +93,9 @@ std::string CreateDir::tempDir(std::string templ)
     char *dir = const_cast<char*>(templ.c_str());
     dir = mkdtemp(dir);
     if (dir == nullptr) {
-        log_warning() << "Failed to create buffered Directory: " << strerror(errno);
-        return nullptr;
+        std::string message = "Failed to create buffered Directory: " + std::string(strerror(errno));
+        log_warning() << message;
+        throw SoftwareContainerError(message);
     }
 
     m_tempFileCleaners.emplace_back(new DirectoryCleanUpHandler(std::string(dir)));

--- a/common/createdir.cpp
+++ b/common/createdir.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include "createdir.h"
+#include <sys/stat.h>
+
+namespace softwarecontainer {
+
+bool CreateDir::createParentDirectory(const std::string path)
+{
+    log_debug() << "Creating parent directories for " << path;
+    std::string parent = parentPath(path);
+
+    if (!createDirectory(parent)) {
+        log_error() << "Could not create directory " << parent;
+        return false;
+    }
+
+    return true;
+}
+
+bool CreateDir::createDirectory(const std::string path)
+{
+    log_debug() << "createDirectory(" << path << ") called";
+    if (isDirectory(path)) {
+        return true;
+    }
+
+    if(!createParentDirectory(path)) {
+        log_error() << "Couldn't create parent directory for " << path;
+        return false;
+    }
+
+    if (mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IRWXO) == -1) {
+        log_error() << "Could not create directory " << path << ": " << strerror(errno);
+        return false;
+    }
+
+    m_cleanupHandlers.emplace_back(new DirectoryCleanUpHandler(path));
+    return true;
+}
+
+void CreateDir::clear()
+{
+    m_cleanupHandlers.clear();
+}
+
+bool CreateDir::rollBack()
+{
+    bool success = true;
+    // Clean up all created directories
+    for (auto &cleanupHandler:m_cleanupHandlers) {
+        if (!cleanupHandler->clean()) {
+            log_error() << cleanupHandler->queryName() << " could not be cleaned!";
+            success = false;
+        }
+    }
+
+    clear();
+    return success;
+}
+
+
+}

--- a/common/createdir.h
+++ b/common/createdir.h
@@ -48,6 +48,26 @@ public:
      *
      * */
     void clear();
+
+    /**
+     * @brief tempDir Creates a uniquely named temporary directory according to templatePath.
+     *
+     * @warning The temporary path will be destroyed when the instance of FileToolkitWithUndo
+     *  is destroyed.
+     *
+     * @param templ a template Path used to create the path of the temporary directory, including
+     *  XXXXXX which will be replaced with a unique ID for the temporary directory
+     *
+     * @return A string path pointing to the newly created temporary directory.
+     */
+    std::string tempDir(std::string templatePath);
+
+    /**
+     * @brief m_tempFileCleaners holds cleanup handler for each created temporary directory.
+     * The main purpose of this is to rollback in any errors while bind-mounting. On success
+     * m_tempFileCleaners will be moved to cleanup handlers of FileToolkitWithUndo
+     */
+    std::vector<std::unique_ptr<DirectoryCleanUpHandler>> m_tempFileCleaners;
 private :
     /**
      * @brief createParentDirectory Recursively tries to create the directory pointed to by path.
@@ -57,10 +77,17 @@ private :
     bool createParentDirectory(const std::string path);
 
     /**
-     * @brief m_createDirectoryCleanupHandlers holds cleanup handler for each created driectory.
+     * @brief m_createDirectoryCleanupHandlers holds cleanup handler for each created directory.
      * The main purpose of this is to rollback in any errors.
      */
-    std::vector<std::unique_ptr<DirectoryCleanUpHandler>> m_cleanupHandlers;
+    std::vector<std::unique_ptr<DirectoryCleanUpHandler>> m_rollbackCleaners;
+
+    /**
+     * @brief checks whether path is already added to m_cleanupHandlers or not
+     * @param a string path name to check
+     * @return true if the path is already exist, false otherwise
+     */
+    bool pathInList(const std::string path);
 };
 
 }

--- a/common/createdir.h
+++ b/common/createdir.h
@@ -21,70 +21,60 @@
 
 namespace softwarecontainer {
 
+/**
+ * @brief The CreateDir class is responsible for creating new directories and removing them when it
+ * is necessary.
+ *
+ * This class is created as a helper to FileToolkitWithUndo class. It adds value to
+ * FileToolkitWithUndo class by creating rollback option on failures.
+ */
 class CreateDir {
     LOG_DECLARE_CLASS_CONTEXT("CD", "Create Directory");
 public:
+    ~CreateDir();
+
     /**
-     * @brief createDirectory Create a directory, and if successful append it
-     *  to a list of dirs to be deleted in the dtor. Since nestled dirs will
-     *  need to be deleted in reverse order to creation insert to the beginning
-     *  of the list.
+     * @brief createDirectory creates a directory according to given path.
+     * The directory will be removed when the object is destroyed.
+     *
      * @param path Path of directory to be created
      * @return true on success, false on failure
      */
     bool createDirectory(const std::string path);
 
     /**
-     * @brief rollBack calls clean method for all members of m_createDirectoryCleanupHandlers.
+     * @brief createTempDirectoryFromTemplate creates a uniquely named directory according to
+     * templatePath.
      *
-     * This function is created as a helper to callers of createDirectory functions. It is strongly
-     * recommended that this functions should be called if createDirectory function returns false.
+     * @warning The created directory will be destroyed when the object is destroyed
      *
-     * @return true on success, false on failure
-     */
-    bool rollBack();
-
-    /*@brief clear removes all elements from the m_createDirectoryCleanupHandlers
-     *
-     * */
-    void clear();
-
-    /**
-     * @brief tempDir Creates a uniquely named temporary directory according to templatePath.
-     *
-     * @warning The temporary path will be destroyed when the instance of FileToolkitWithUndo
-     *  is destroyed.
-     *
-     * @param templ a template Path used to create the path of the temporary directory, including
-     *  XXXXXX which will be replaced with a unique ID for the temporary directory
+     * @param templatePath is used to create the path of the temporary directory. The last six
+     * characters of template must be XXXXXX and these are replaced with a string that makes the
+     * directory name unique.
      *
      * @throws SoftwareContainerError if template path is not appropriate.
      * @return A string path pointing to the newly created temporary directory.
      */
-    std::string tempDir(std::string templatePath);
+    std::string createTempDirectoryFromTemplate(std::string templatePath);
 
-    /**
-     * @brief m_tempFileCleaners holds cleanup handler for each created temporary directory.
-     * The main purpose of this is to rollback in any errors while bind-mounting. On success
-     * m_tempFileCleaners will be moved to cleanup handlers of FileToolkitWithUndo
-     */
-    std::vector<std::unique_ptr<DirectoryCleanUpHandler>> m_tempFileCleaners;
 private :
     /**
      * @brief createParentDirectory Recursively tries to create the directory pointed to by path.
+     *
      * @param path The directory path to be created.
      * @return true on success, false on failure
      */
     bool createParentDirectory(const std::string path);
 
     /**
-     * @brief m_createDirectoryCleanupHandlers holds cleanup handler for each created directory.
-     * The main purpose of this is to rollback in any errors.
+     * @brief holds cleanup handler for each created directory.
+     * The main purpose of this is to rollback in any errors or when the object is
      */
-    std::vector<std::unique_ptr<DirectoryCleanUpHandler>> m_rollbackCleaners;
+    std::vector<DirectoryCleanUpHandler> m_rollbackCleaners;
 
     /**
-     * @brief checks whether path is already added to m_cleanupHandlers or not
+     * @brief checks whether path is already added to m_rollbackCleaners or not
+     *
      * @param a string path name to check
      * @return true if the path is already exist, false otherwise
      */

--- a/common/createdir.h
+++ b/common/createdir.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include "directorycleanuphandler.h"
+
+namespace softwarecontainer {
+
+class CreateDir {
+    LOG_DECLARE_CLASS_CONTEXT("CD", "Create Directory");
+public:
+    /**
+     * @brief createDirectory Create a directory, and if successful append it
+     *  to a list of dirs to be deleted in the dtor. Since nestled dirs will
+     *  need to be deleted in reverse order to creation insert to the beginning
+     *  of the list.
+     * @param path Path of directory to be created
+     * @return true on success, false on failure
+     */
+    bool createDirectory(const std::string path);
+
+    /**
+     * @brief rollBack calls clean method for all members of m_createDirectoryCleanupHandlers.
+     *
+     * This function is created as a helper to callers of createDirectory functions. It is strongly
+     * recommended that this functions should be called if createDirectory function returns false.
+     *
+     * @return true on success, false on failure
+     */
+    bool rollBack();
+
+    /*@brief clear removes all elements from the m_createDirectoryCleanupHandlers
+     *
+     * */
+    void clear();
+private :
+    /**
+     * @brief createParentDirectory Recursively tries to create the directory pointed to by path.
+     * @param path The directory path to be created.
+     * @return true on success, false on failure
+     */
+    bool createParentDirectory(const std::string path);
+
+    /**
+     * @brief m_createDirectoryCleanupHandlers holds cleanup handler for each created driectory.
+     * The main purpose of this is to rollback in any errors.
+     */
+    std::vector<std::unique_ptr<DirectoryCleanUpHandler>> m_cleanupHandlers;
+};
+
+}

--- a/common/createdir.h
+++ b/common/createdir.h
@@ -58,6 +58,7 @@ public:
      * @param templ a template Path used to create the path of the temporary directory, including
      *  XXXXXX which will be replaced with a unique ID for the temporary directory
      *
+     * @throws SoftwareContainerError if template path is not appropriate.
      * @return A string path pointing to the newly created temporary directory.
      */
     std::string tempDir(std::string templatePath);

--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -145,7 +145,7 @@ bool FileToolkitWithUndo::overlayMount(const std::string &lower,
         return false;
     }
     m_create.clear();
-    log_debug() << "adding mount points";
+
     if (!pathInList(lower)) {
         m_cleanupHandlers.emplace_back(new DirectoryCleanUpHandler(lower));
     }

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "cleanuphandler.h"
+#include "createdir.h"
 #include "softwarecontainer-common.h"
 
 namespace softwarecontainer {
@@ -103,16 +104,6 @@ protected:
     bool createSharedMountPoint(const std::string &path);
 
     /**
-     * @brief createDirectory Create a directory, and if successful append it
-     *  to a list of dirs to be deleted in the dtor. Since nestled dirs will
-     *  need to be deleted in reverse order to creation insert to the beginning
-     *  of the list.
-     * @param path Path of directory to be created
-     * @return true on success, false on failure
-     */
-    bool createDirectory(const std::string &path);
-
-    /**
      * @brief checks whether given path is already added to clean up handlers or not
      *
      * This function will be called only before adding new CleanUpHandler for FileCleanUpHandler
@@ -129,13 +120,8 @@ protected:
      *  FileToolKitWithUndo that will be run from the destructor.
      */
     std::vector<CleanUpHandler *> m_cleanupHandlers;
-private :
-    /**
-     * @brief createParentDirectory Recursively tries to create the directory pointed to by path.
-     * @param path The directory path to be created.
-     * @return true on success, false on failure
-     */
-    bool createParentDirectory(const std::string &path);
+
+    CreateDir m_create;
 };
 
 } // namespace softwarecontainer

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "cleanuphandler.h"
+#include "mountcleanuphandler.h"
 #include "createdir.h"
 #include "softwarecontainer-common.h"
 
@@ -47,15 +47,6 @@ public:
                    bool enableWriteBuffer=false);
 
 
-    /**
-     * @brief tempDir Creates a temporary directory at templatePath.
-     * @warning The temporary path will be destroyed when the instance of FileToolkitWithUndo
-     *  is destroyed.
-     * @param templ a template Path used to create the path of the temporary directory, including
-     *  XXXXXX which will be replaced with a unique ID for the temporary directory
-     * @return A string path pointing to the newly creted temporary directory.
-     */
-    std::string tempDir(std::string templatePath);
 protected:
     /*
      * @brief Writes to a file (and optionally create it)

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -112,7 +112,11 @@ protected:
      */
     std::vector<std::unique_ptr<CleanUpHandler>> m_cleanupHandlers;
 
-    CreateDir m_create;
+    /**
+     * @brief m_createDirList A vector of CreateDir classes. This class handles directory cleaning
+     * operations when either interfered errors or when its destructor runs.
+     */
+    std::vector<std::unique_ptr<CreateDir>> m_createDirList;
 };
 
 } // namespace softwarecontainer

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -119,7 +119,7 @@ protected:
      * @brief m_cleanupHandlers A vector of cleanupHandlers added during the lifetime of the
      *  FileToolKitWithUndo that will be run from the destructor.
      */
-    std::vector<CleanUpHandler *> m_cleanupHandlers;
+    std::vector<std::unique_ptr<CleanUpHandler>> m_cleanupHandlers;
 
     CreateDir m_create;
 };

--- a/common/unit-test/CMakeLists.txt
+++ b/common/unit-test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_LIBRARY_DEPENDENCIES
 
 set(TEST_FILES
     softwarecontainer-common_unittest.cpp
+    createdir_unittest.cpp
     recursivecopy_unittest.cpp
     recursivedelete_unittest.cpp
     unittest_common_helpers.cpp

--- a/common/unit-test/createdir_unittest.cpp
+++ b/common/unit-test/createdir_unittest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Pelagicore AB
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ * ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ *
+ * For further information see LICENSE
+ */
+
+#include "createdir.h"
+#include "softwarecontainererror.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+
+using namespace softwarecontainer;
+
+class CreateDirTest: public ::testing::Test
+{
+public:
+
+    void SetUp() override
+    {
+    }
+
+    CreateDir cd;
+
+};
+
+
+TEST_F(CreateDirTest, createNestedDir)
+{
+    ASSERT_TRUE(cd.createDirectory("time/to/test/nested/directory/creation"));
+    ASSERT_TRUE(cd.rollBack());
+}
+
+TEST_F(CreateDirTest, createExistingDir)
+{
+    ASSERT_TRUE(cd.createDirectory("test/double/creation"));
+    ASSERT_TRUE(cd.createDirectory("test/double/creation"));
+    ASSERT_TRUE(cd.rollBack());
+}
+
+TEST_F(CreateDirTest, DISABLED_creationError)
+{
+    ASSERT_TRUE(cd.createDirectory("/tmp/test/error/in/nested"));
+    chmod("/tmp/test/error/in/nested", 444);
+    ASSERT_FALSE(cd.createDirectory("/tmp/test/error/in/nested/directory/error"));
+    ASSERT_TRUE(cd.rollBack());
+}
+
+TEST_F(CreateDirTest, tempError)
+{
+    EXPECT_THROW(cd.tempDir("tmp/sc-unappropriate/template"), SoftwareContainerError);
+    ASSERT_TRUE(cd.rollBack());
+}

--- a/common/unit-test/recursivecopy_unittest.cpp
+++ b/common/unit-test/recursivecopy_unittest.cpp
@@ -30,18 +30,18 @@
 
 using namespace softwarecontainer;
 
-class RecursiveCopyTest: public ::testing::Test
+class RecursiveCopyTest: public ::testing::Test, CreateDir
 {
 public:
     RecursiveCopyTest() { }
 
     void SetUp() override
     {
-        srcdir = ft.tempDir("/tmp/sc-recursivecopyTest-XXXXXX");
-        dstdir = ft.tempDir("/tmp/sc-recursivecopyTest-XXXXXX");
+        srcdir = cd.tempDir("/tmp/sc-recursivecopyTest-XXXXXX");
+        dstdir = cd.tempDir("/tmp/sc-recursivecopyTest-XXXXXX");
     }
 
-    FileToolkitWithUndo ft;
+    CreateDir cd;
     std::string srcdir;
     std::string dstdir;
 };

--- a/common/unit-test/recursivecopy_unittest.cpp
+++ b/common/unit-test/recursivecopy_unittest.cpp
@@ -21,7 +21,6 @@
 #include <filetoolkitwithundo.h>
 #include <recursivecopy.h>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <unistd.h>
 #include <fstream>

--- a/common/unit-test/recursivecopy_unittest.cpp
+++ b/common/unit-test/recursivecopy_unittest.cpp
@@ -36,8 +36,8 @@ public:
 
     void SetUp() override
     {
-        srcdir = cd.tempDir("/tmp/sc-recursivecopyTest-XXXXXX");
-        dstdir = cd.tempDir("/tmp/sc-recursivecopyTest-XXXXXX");
+        srcdir = cd.createTempDirectoryFromTemplate("/tmp/sc-recursivecopyTest-XXXXXX");
+        dstdir = cd.createTempDirectoryFromTemplate("/tmp/sc-recursivecopyTest-XXXXXX");
     }
 
     CreateDir cd;

--- a/common/unit-test/recursivedelete_unittest.cpp
+++ b/common/unit-test/recursivedelete_unittest.cpp
@@ -37,7 +37,7 @@ public:
 
     void SetUp() override
     {
-        workdir = cd.tempDir("/tmp/sc-RecursiveDeleteTest-XXXXXX");
+        workdir = cd.createTempDirectoryFromTemplate("/tmp/sc-RecursiveDeleteTest-XXXXXX");
         testdir = buildPath(workdir, "testdir");
         createDir(testdir);
 

--- a/common/unit-test/recursivedelete_unittest.cpp
+++ b/common/unit-test/recursivedelete_unittest.cpp
@@ -37,13 +37,13 @@ public:
 
     void SetUp() override
     {
-        workdir = ft.tempDir("/tmp/sc-RecursiveDeleteTest-XXXXXX");
+        workdir = cd.tempDir("/tmp/sc-RecursiveDeleteTest-XXXXXX");
         testdir = buildPath(workdir, "testdir");
         createDir(testdir);
 
     }
 
-    FileToolkitWithUndo ft;
+    CreateDir cd;
     std::string testdir;
     std::string workdir;
 };

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -110,12 +110,14 @@ bool Container::initialize()
 {
     if (m_state < ContainerState::PREPARED) {
         std::string gatewayDir = gatewaysDir();
-        if (!createDirectory(gatewayDir)) {
+        if (!m_create.createDirectory(gatewayDir)) {
+            m_create.rollBack();
             log_error() << "Could not create gateway directory "
                         << gatewayDir << ": " << strerror(errno);
             return false;
         }
-
+        m_create.clear();
+//        TODO: add filetoolkit cleanupHandler here
         if (!createSharedMountPoint(gatewayDir)) {
             log_error() << "Could not create shared mount point for dir: " << gatewayDir;
             return false;
@@ -608,10 +610,13 @@ bool Container::bindMountInContainer(const std::string &pathInHost,
         log_debug() << "Path on host (" << pathInHost << ") is directory, mounting as a directory";
 
         log_debug() << "Creating folder : " << tempPath;
-        if (!createDirectory(tempPath)) {
+        if (!m_create.createDirectory(tempPath)) {
+            m_create.rollBack();
             log_error() << "Could not create folder " << tempPath;
             return false;
         }
+        m_create.clear();
+//        TODO :add filetoolkit cleanupHandler here
     } else {
         // This goes for sockets, fifos etc as well.
         log_debug() << "Path on host (" << pathInHost << ") is not a directory, "

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -627,7 +627,7 @@ bool Container::bindMountInContainer(const std::string &pathInHost,
                 log_error() << "Could not create file " << tempPath;
                 return false;
             }
-            m_cleanupHandlers.push_back(new FileCleanUpHandler(tempPath));
+            m_cleanupHandlers.emplace_back(new FileCleanUpHandler(tempPath));
         }
     }
 

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -447,7 +447,9 @@ void SoftwareContainer::checkWorkspace()
             throw SoftwareContainerError(message);
         }
         m_create.clear();
-//      TODO: add filetoolkit cleanupHandler here
+        if (!pathInList(rootDir)) {
+            m_cleanupHandlers.emplace_back(new DirectoryCleanUpHandler(rootDir));
+        }
     }
 }
 

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -440,16 +440,14 @@ void SoftwareContainer::checkWorkspace()
     const std::string rootDir = m_config->sharedMountsDir();
     if (!isDirectory(rootDir)) {
         log_debug() << "Container root " << rootDir << " does not exist, trying to create";
-        if(!m_create.createDirectory(rootDir)) {
-            m_create.rollBack();
+        std::unique_ptr<CreateDir> createDirInstance = std::unique_ptr<CreateDir>(new CreateDir());
+        if(!createDirInstance->createDirectory(rootDir)) {
             std::string message = "Failed to create container root directory";
             log_error() << message;
             throw SoftwareContainerError(message);
         }
-        m_create.clear();
-        if (!pathInList(rootDir)) {
-            m_cleanupHandlers.emplace_back(new DirectoryCleanUpHandler(rootDir));
-        }
+
+        m_createDirList.push_back(std::move(createDirInstance));
     }
 }
 

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -440,11 +440,14 @@ void SoftwareContainer::checkWorkspace()
     const std::string rootDir = m_config->sharedMountsDir();
     if (!isDirectory(rootDir)) {
         log_debug() << "Container root " << rootDir << " does not exist, trying to create";
-        if(!createDirectory(rootDir)) {
+        if(!m_create.createDirectory(rootDir)) {
+            m_create.rollBack();
             std::string message = "Failed to create container root directory";
             log_error() << message;
             throw SoftwareContainerError(message);
         }
+        m_create.clear();
+//      TODO: add filetoolkit cleanupHandler here
     }
 }
 


### PR DESCRIPTION
CreateDir: Add a new class to track to hold directory creation backlog.
FileToolkitWithUndo: Use smart pointer instead of raw pointer.
Rollback on failed unmount operations
unittests for CreateDir class

Note : one tests marked to be skipped. It is necessary to mark it as "DISABLED" due to current CI conditions. 