### PR TITLE
examples: Add mandatory system config to temp

### DIFF
--- a/examples/temperature/temperature-service/configs/temperature-service.json
+++ b/examples/temperature/temperature-service/configs/temperature-service.json
@@ -6,7 +6,7 @@
                 {
                     "id": "dbus",
                     "config": [
-                        { "dbus-gateway-config-session": [
+                        { "dbus-gateway-config-system": [
                              {
                                  "direction": "outgoing",
                                  "interface": "org.freedesktop.DBus.Introspectable",
@@ -42,7 +42,7 @@
                 {
                     "id": "dbus",
                     "config": [
-                        { "dbus-gateway-config-session": [
+                        { "dbus-gateway-config-system": [
                             {
                                 "direction": "outgoing",
                                 "interface": "org.freedesktop.DBus.Introspectable",


### PR DESCRIPTION
The temperature example failed due to an incorrectly formatted
service manifest.
Added an empty D-Bus system config, instead of omitting it entirely.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>