### PR TITLE
dbusgateway: change log level for config and activate

### DIFF
--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayinstance.cpp
@@ -72,7 +72,9 @@ bool DBusGatewayInstance::readConfigElement(const json_t *element)
 
     // TODO: This should really be done with exceptions instead and json_t* as return type.
     if (!parser.parseDBusConfig(element, typeStr, m_busConfig)) {
-        log_error() << "Failed to parse DBus configuration element";
+        // This might also mean that only one of session or system bus config parsing failed
+        // so this is not a fatal error
+        log_warning() << "Failed to parse DBus configuration element";
         return false;
     }
 

--- a/libsoftwarecontainer/src/gateway/dbus/dbusgatewayparser.cpp
+++ b/libsoftwarecontainer/src/gateway/dbus/dbusgatewayparser.cpp
@@ -30,7 +30,7 @@ bool DBusGatewayParser::parseDBusConfig(const json_t *element,
     json_t *configExists = json_object_get(element, key);
     if (nullptr == configExists) {
         // This is not a fatal error - not providing the key for one of the buses is OK.
-        log_error() << key << " was not found in config.";
+        log_warning() << key << " was not found in config.";
         return false;
     }
 

--- a/libsoftwarecontainer/src/gateway/gateway.cpp
+++ b/libsoftwarecontainer/src/gateway/gateway.cpp
@@ -65,7 +65,7 @@ bool Gateway::setConfig(const json_t *config)
         }
 
         if (!readConfigElement(element)) {
-            log_error() << "Could not read config element";
+            log_warning() << "Could not read config element";
             return false;
         }
     }


### PR DESCRIPTION
Since the session and system bus can be used on its own without the other
change the log level for config error and activation error to warning.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>