### PR TITLE
conftest.py: Fixes assert_no_proxy fixture

### DIFF
--- a/servicetest/conftest.py
+++ b/servicetest/conftest.py
@@ -172,7 +172,7 @@ def testhelper(request):
 
 def grep_for_dbus_proxy():
     """ Helper for 'assert_no_proxy' """
-    return os.system('ps -aux | grep dbus-proxy | grep -v "grep" | grep prefix-dbus- > /dev/null')
+    return os.popen('ps -aux | grep dbus-proxy | grep -v "grep"').read()
 
 
 @pytest.fixture(scope="function")
@@ -181,9 +181,9 @@ def assert_no_proxy():
 
         Do the check both on setup and teardown
     """
-    assert grep_for_dbus_proxy() != 0, "dbus-proxy is alive when it shouldn't be"
+    assert "dbus-proxy" not in grep_for_dbus_proxy(), "dbus-proxy is alive when it shouldn't be"
     yield
-    assert grep_for_dbus_proxy() != 0, "dbus-proxy is alive when it shouldn't be"
+    assert "dbus-proxy" not in grep_for_dbus_proxy(), "dbus-proxy is alive when it shouldn't be"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Fixture previously gave false positives, now it will
fail the test if dbus-proxy is running when it shouldn't
be.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>