### PR TITLE
workspace: Move checkWorkspace

### DIFF
--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -104,8 +104,8 @@ public:
                                                                   ConfigDependencies());
 
         try {
-            auto factory = std::make_shared<SoftwareContainerFactory> ();
-            auto utility = std::make_shared<ContainerUtilityInterface> (config);
+            auto factory = std::make_shared<SoftwareContainerFactory>();
+            auto utility = std::make_shared<ContainerUtilityInterface>(config);
             sca = std::make_shared<SoftwareContainerAgent>(m_context, config, factory, utility);
         }  catch(SoftwareContainerError &err) {
             log_error() << "Exception in software agent constructor";

--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -104,8 +104,8 @@ public:
                                                                   ConfigDependencies());
 
         try {
-            std::shared_ptr<SoftwareContainerFactory> factory = std::shared_ptr<SoftwareContainerFactory> (new SoftwareContainerFactory());
-            std::shared_ptr<ContainerUtilityInterface> utility = std::shared_ptr<ContainerUtilityInterface> (new ContainerUtilityInterface());
+            auto factory = std::make_shared<SoftwareContainerFactory> ();
+            auto utility = std::make_shared<ContainerUtilityInterface> (config);
             sca = std::make_shared<SoftwareContainerAgent>(m_context, config, factory, utility);
         }  catch(SoftwareContainerError &err) {
             log_error() << "Exception in software agent constructor";

--- a/agent/src/containerutilityinterface.cpp
+++ b/agent/src/containerutilityinterface.cpp
@@ -83,7 +83,7 @@ void ContainerUtilityInterface::checkWorkspace()
     const std::string rootDir = m_config->getStringValue("SoftwareContainer", "shared-mounts-dir");
     if (!isDirectory(rootDir)) {
         log_debug() << "Container root " << rootDir << " does not exist, trying to create";
-        std::unique_ptr<CreateDir> createDirInstance{new CreateDir()};
+        std::unique_ptr<CreateDir> createDirInstance(new CreateDir());
         if(!createDirInstance->createDirectory(rootDir)) {
             std::string message = "Failed to create container root directory";
             log_error() << message;

--- a/agent/src/containerutilityinterface.h
+++ b/agent/src/containerutilityinterface.h
@@ -70,7 +70,7 @@ class ContainerUtilityInterface : private FileToolkitWithUndo
     LOG_DECLARE_CLASS_CONTEXT("CUI", "Container Utility Interface");
 public:
     ContainerUtilityInterface(std::shared_ptr<Config> config);
-    ~ContainerUtilityInterface() {}
+    virtual ~ContainerUtilityInterface() {}
 
     /**
      * @brief This method cleans unused old containers before agent starts up

--- a/agent/src/containerutilityinterface.h
+++ b/agent/src/containerutilityinterface.h
@@ -25,6 +25,10 @@
 
 #include "softwarecontainer-log.h"
 #include "softwarecontainererror.h"
+#include "config/config.h"
+#include "filetoolkitwithundo.h"
+
+#include <memory>
 
 namespace softwarecontainer {
 
@@ -61,15 +65,24 @@ protected:
  * This class contains utility functions
  */
 
-class ContainerUtilityInterface {
+class ContainerUtilityInterface : private FileToolkitWithUndo
+{
     LOG_DECLARE_CLASS_CONTEXT("CUI", "Container Utility Interface");
 public:
-    virtual ~ContainerUtilityInterface() {}
+    ContainerUtilityInterface(std::shared_ptr<Config> config);
+    ~ContainerUtilityInterface() {}
 
     /**
      * @brief This method cleans unused old containers before agent starts up
      */
-    virtual void removeOldContainers(void);
+    void removeOldContainers(void);
+    /**
+     * @brief Check that the workspace exists.
+     */
+    void checkWorkspace(void);
+
+private:
+    std::shared_ptr<Config> m_config;
 };
 
 } //namespace

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -216,8 +216,8 @@ int main(int argc, char **argv)
         std::shared_ptr<Config> config = std::make_shared<Config>(std::move(configSources),
                                                                   ConfigDefinition::mandatory(),
                                                                   ConfigDependencies());
-        auto factory = std::make_shared<SoftwareContainerFactory> ();
-        auto utility = std::make_shared<ContainerUtilityInterface> (config);
+        auto factory = std::make_shared<SoftwareContainerFactory>();
+        auto utility = std::make_shared<ContainerUtilityInterface>(config);
 
         // Create the actual agent
         ::softwarecontainer::SoftwareContainerAgent agent(mainContext, config, factory, utility);

--- a/agent/src/main.cpp
+++ b/agent/src/main.cpp
@@ -216,10 +216,8 @@ int main(int argc, char **argv)
         std::shared_ptr<Config> config = std::make_shared<Config>(std::move(configSources),
                                                                   ConfigDefinition::mandatory(),
                                                                   ConfigDependencies());
-        std::shared_ptr<SoftwareContainerFactory> factory =
-            std::shared_ptr<SoftwareContainerFactory> (new SoftwareContainerFactory());
-        std::shared_ptr<ContainerUtilityInterface> utility =
-            std::shared_ptr<ContainerUtilityInterface> (new ContainerUtilityInterface());
+        auto factory = std::make_shared<SoftwareContainerFactory> ();
+        auto utility = std::make_shared<ContainerUtilityInterface> (config);
 
         // Create the actual agent
         ::softwarecontainer::SoftwareContainerAgent agent(mainContext, config, factory, utility);

--- a/agent/src/softwarecontaineragent.cpp
+++ b/agent/src/softwarecontaineragent.cpp
@@ -81,6 +81,7 @@ SoftwareContainerAgent::SoftwareContainerAgent(Glib::RefPtr<Glib::MainContext> m
     m_defaultConfigStore  = std::make_shared<DefaultConfigStore>(std::move(defaultLoader));
 
     m_containerUtility->removeOldContainers();
+    m_containerUtility->checkWorkspace();
 
     m_containerConfig = SoftwareContainerConfig(
 #ifdef ENABLE_NETWORKGATEWAY

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -152,11 +152,11 @@ public:
                                                                   ConfigDependencies());
 
         Glib::RefPtr<Glib::MainContext> mainContext = Glib::MainContext::get_default();
-        testContainerInterface = std::shared_ptr<::testing::NiceMock<TestContainerInterface>> (new ::testing::NiceMock<TestContainerInterface>());
-        factory = std::shared_ptr<SoftwareContainerFactory> (new TestFactory(testContainerInterface));
-        containerUtility = std::shared_ptr<::testing::NiceMock<MockUtility>> (new ::testing::NiceMock<MockUtility>(config));
+        testContainerInterface = std::shared_ptr<::testing::NiceMock<TestContainerInterface>>(new ::testing::NiceMock<TestContainerInterface>());
+        factory = std::shared_ptr<SoftwareContainerFactory>(new TestFactory(testContainerInterface));
+        containerUtility = std::shared_ptr<::testing::NiceMock<MockUtility>>(new ::testing::NiceMock<MockUtility>(config));
 
-        sca = std::unique_ptr<SoftwareContainerAgent> (new SoftwareContainerAgent(mainContext, config, factory, containerUtility));
+        sca = std::unique_ptr<SoftwareContainerAgent>(new SoftwareContainerAgent(mainContext, config, factory, containerUtility));
 
         ::testing::DefaultValue<bool>::Set(true);
         ::testing::DefaultValue<std::shared_ptr<CommandJob>>::Set(nullptr);

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -105,7 +105,9 @@ public:
 class MockUtility : public ContainerUtilityInterface
 {
 public:
-
+    MockUtility(std::shared_ptr<Config> config) :
+        ContainerUtilityInterface(config)
+    {}
     MOCK_METHOD0(removeOldContainers, void());
 };
 
@@ -152,7 +154,7 @@ public:
         Glib::RefPtr<Glib::MainContext> mainContext = Glib::MainContext::get_default();
         testContainerInterface = std::shared_ptr<::testing::NiceMock<TestContainerInterface>> (new ::testing::NiceMock<TestContainerInterface>());
         factory = std::shared_ptr<SoftwareContainerFactory> (new TestFactory(testContainerInterface));
-        containerUtility = std::shared_ptr<::testing::NiceMock<MockUtility>> (new ::testing::NiceMock<MockUtility>());
+        containerUtility = std::shared_ptr<::testing::NiceMock<MockUtility>> (new ::testing::NiceMock<MockUtility>(config));
 
         sca = std::unique_ptr<SoftwareContainerAgent> (new SoftwareContainerAgent(mainContext, config, factory, containerUtility));
 

--- a/common/createdir.h
+++ b/common/createdir.h
@@ -17,6 +17,8 @@
  * For further information see LICENSE
  */
 
+#pragma once
+
 #include "directorycleanuphandler.h"
 
 namespace softwarecontainer {

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -46,6 +46,14 @@ public:
                    bool readOnly,
                    bool enableWriteBuffer=false);
 
+    /**
+     * @brief tmpfsMount Mount a tmpfs in the dst path and limit size of the
+     *  tmpfs to maxSize
+     * @param dst The destination to mount a tmpfs on
+     * @param maxSize The max size of the tmpfs being mounted
+     * @return
+     */
+    bool tmpfsMount(const std::string dst, const int maxSize);
 
 protected:
     /*

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -333,7 +333,7 @@ private:
     void assertValidState();
 
     // Check if the workspace is sound, and set it up if it isn't
-    void checkWorkspace();
+    void checkContainerRoot(std::string rootDir);
 #ifdef ENABLE_NETWORKGATEWAY
     void checkNetworkSettings();
 #endif // ENABLE_NETWORKGATEWAY
@@ -345,6 +345,8 @@ private:
 
     std::vector<std::unique_ptr<Gateway>> m_gateways;
     std::unique_ptr<const SoftwareContainerConfig> m_config;
+
+    std::string m_containerRoot;
 
     Glib::RefPtr<Glib::MainContext> m_mainLoopContext;
     SignalConnectionsHandler m_connections;

--- a/libsoftwarecontainer/include/softwarecontainer.h
+++ b/libsoftwarecontainer/include/softwarecontainer.h
@@ -347,6 +347,7 @@ private:
     std::unique_ptr<const SoftwareContainerConfig> m_config;
 
     std::string m_containerRoot;
+    unsigned int m_tmpfsSize;
 
     Glib::RefPtr<Glib::MainContext> m_mainLoopContext;
     SignalConnectionsHandler m_connections;

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -190,9 +190,9 @@ bool Container::create()
     m_rootFSPath = buildPath(s_LXCRoot, containerID, "rootfs");
 
     if (m_enableWriteBuffer) {
-        const std::string rootFSPathLower = m_containerRoot + m_id + "/rootfs-lower";
-        const std::string rootFSPathUpper = m_containerRoot + m_id + "/rootfs-upper";
-        const std::string rootFSPathWork  = m_containerRoot + m_id + "/rootfs-work";
+        const std::string rootFSPathLower = m_containerRoot + "/rootfs-lower";
+        const std::string rootFSPathUpper = m_containerRoot + "/rootfs-upper";
+        const std::string rootFSPathWork  = m_containerRoot + "/rootfs-work";
 
         overlayMount(rootFSPathLower, rootFSPathUpper, rootFSPathWork, m_rootFSPath);
         log_debug() << "Write buffer enabled, lowerdir=" << rootFSPathLower
@@ -663,7 +663,7 @@ bool Container::bindMountCore(const std::string &pathInHost,
     // Bind mount to /gateways
     if (!bindMount(pathInHost,
                    tempDirInContainerOnHost,
-                   m_containerRoot + m_id,
+                   m_containerRoot,
                    readonly,
                    m_enableWriteBuffer)) {
         log_error() << "Could not bind mount " << pathInHost << " to " << tempDirInContainerOnHost;
@@ -872,7 +872,7 @@ std::string Container::gatewaysDirInContainer() const
 
 std::string Container::gatewaysDir() const
 {
-    return buildPath(m_containerRoot, id(), GATEWAYS_PATH);
+    return buildPath(m_containerRoot, GATEWAYS_PATH);
 }
 
 } // namespace softwarecontainer

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -62,9 +62,10 @@ SoftwareContainer::SoftwareContainer(const ContainerID id,
     m_previouslyConfigured(false)
 {
     m_containerRoot = buildPath(m_config->sharedMountsDir(), "SC-" + std::to_string(id));
+    m_tmpfsSize = 100485760;
     checkContainerRoot(m_containerRoot);
     if (m_config->enableWriteBuffer()) {
-        tmpfsMount(m_containerRoot, 100485760);
+        tmpfsMount(m_containerRoot, m_tmpfsSize);
     }
 
 #ifdef ENABLE_NETWORKGATEWAY

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -79,8 +79,6 @@ SoftwareContainer::SoftwareContainer(const ContainerID id,
                       m_config->enableWriteBuffer(),
                       m_config->containerShutdownTimeout()));
 
-
-
     if(!init()) {
         throw SoftwareContainerError("Could not initialize SoftwareContainer, container ID: "
                                      + std::to_string(id));


### PR DESCRIPTION
This commit moves the checkWorkspace method from the SoftwareContainer to the
ContainerUtilityInterface and the usage into the SoftwareContainerAgent class
as the workspace is connected to the agent, not each container. A new check
was added to the SoftwareContainer for the containerRoot (previously
workspace).

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>