### PR TITLE
writebuffers: Temp filesystem support

### DIFF
--- a/agent/src/containeroptions/containeroptionparser.cpp
+++ b/agent/src/containeroptions/containeroptionparser.cpp
@@ -23,6 +23,7 @@
 
 namespace softwarecontainer {
 
+
 ContainerOptionParser::ContainerOptionParser() :
     m_options(new DynamicContainerOptions())
 {
@@ -36,14 +37,37 @@ void ContainerOptionParser::readConfigElement(const json_t *element)
         throw ContainerOptionParseError(errorMessage);
     }
 
-    bool wo = false;
-    if(!JSONParser::read(element, "enableWriteBuffer", wo)) {
+    bool enableWriteBuffer = false;
+    if(!JSONParser::read(element, "enableWriteBuffer", enableWriteBuffer)) {
         std::string errorMessage("Could not parse config due to: 'enableWriteBuffer' not found.");
         log_error() << errorMessage;
         throw ContainerOptionParseError(errorMessage);
     }
 
-    m_options->setEnableWriteBuffer(wo);
+    m_options->setEnableWriteBuffer(enableWriteBuffer);
+
+    if (enableWriteBuffer == true) {
+        bool enableTemporaryFilesystemWriteBuffer = false;
+        if(!JSONParser::read(element,
+                             "enableTemporaryFileSystemWriteBuffer",
+                             enableTemporaryFilesystemWriteBuffer))
+        {
+            log_warn() << "Could not parse config due to: 'enableTemporaryFilesystemWriteBuffer' not found.";
+        }
+        m_options->setEnableTemporaryFileSystemWriteBuffers(enableTemporaryFilesystemWriteBuffer);
+
+        if (enableTemporaryFilesystemWriteBuffer) {
+            int temporaryFileSystemSize = DEFAULT_TEMPORARY_FILESYSTEM_SIZE;
+            if(!JSONParser::read(element,
+                                 "temporaryFileSystemSize",
+                                 temporaryFileSystemSize))
+            {
+                log_error() << "Could not parse config due to: 'temporaryFileSystemSize' not found.";
+            }
+            m_options->setTemporaryFileSystemSize(temporaryFileSystemSize);
+        }
+    }
+
 }
 
 std::unique_ptr<DynamicContainerOptions> ContainerOptionParser::parse(const std::string &config)

--- a/agent/src/containeroptions/containeroptionparser.h
+++ b/agent/src/containeroptions/containeroptionparser.h
@@ -79,6 +79,8 @@ private:
     void readConfigElement(const json_t *element);
 
     std::unique_ptr<DynamicContainerOptions> m_options;
+
+    static constexpr int DEFAULT_TEMPORARY_FILESYSTEM_SIZE = 100 * 1024 * 1024;
 };
 
 } // namespace softwarecontainer

--- a/agent/src/containeroptions/dynamiccontaineroptions.cpp
+++ b/agent/src/containeroptions/dynamiccontaineroptions.cpp
@@ -40,4 +40,24 @@ bool DynamicContainerOptions::enableWriteBuffer() const
     return m_enableWriteBuffer;
 }
 
+void DynamicContainerOptions::setEnableTemporaryFileSystemWriteBuffers(bool enabled)
+{
+    m_enableTemporaryFileSystemWriteBuffers = enabled;
+}
+
+bool DynamicContainerOptions::enableTemporaryFileSystemWriteBuffers() const
+{
+    return m_enableTemporaryFileSystemWriteBuffers;
+}
+
+void DynamicContainerOptions::setTemporaryFileSystemSize(unsigned int size)
+{
+    m_temporaryFileSystemSize = size;
+}
+
+unsigned int DynamicContainerOptions::temporaryFileSystemSize() const
+{
+    return m_temporaryFileSystemSize;
+}
+
 } // namespace softwarecontainer

--- a/agent/src/containeroptions/dynamiccontaineroptions.h
+++ b/agent/src/containeroptions/dynamiccontaineroptions.h
@@ -44,8 +44,32 @@ public:
     void setEnableWriteBuffer(bool enabled);
     bool enableWriteBuffer() const;
 
+    /**
+     * @brief Setter for the enableTemporaryFileSystemWriteBuffers variable used to tell the container
+     * if it shall mount a separate tmpfs on top of the temp directory
+     */
+    void setEnableTemporaryFileSystemWriteBuffers(bool enabled);
+    /**
+     * @brief Getter for the enableTemporaryFileSystemWriteBuffers variable
+     */
+    bool enableTemporaryFileSystemWriteBuffers() const;
+
+    /**
+     * @brief Setter for the temporaryFileSystemSize which is used to tell the system the size of the
+     * tmpfs being mounted on the temp directory.
+     * @param size in bytes of the filesystem
+     */
+    void setTemporaryFileSystemSize(unsigned int size);
+    /**
+     * @brief Getter for the temporaryFileSystemSize variable.
+     * @return the size
+     */
+    unsigned int temporaryFileSystemSize() const;
+
 private:
     bool m_enableWriteBuffer = false;
+    bool m_enableTemporaryFileSystemWriteBuffers = false;
+    unsigned int m_temporaryFileSystemSize;
 };
 
 } // namespace softwarecontainer

--- a/doc/chapters/filesystem/index.rst
+++ b/doc/chapters/filesystem/index.rst
@@ -136,3 +136,36 @@ changes performed during its runtime to be merged into the lower layers.
 .. Note:: Non-directory types of files can not be mounted using overlayfs.
           These will automatically fall back on using the default behavior of 
           bind mounting the files into the filesystem of the container.
+
+Temporary Filesystem
+====================
+
+The write buffers can be configured to use a separate temporary filesystem
+(``tmpfs``) which can be limited in size. The ``tmpfs`` is mounted on top of
+the containers temporary directory as soon as it's created and will remain
+there until the container is destroyed. All ``overlayfs`` mounts and temporary
+directories should be created inside this ``tmpfs`` mount.
+
+The ``size`` of the ``tmpfs`` can also be limited using an extra configuration
+option in the ``Create`` DBus call to the ``SoftwareContainerAgent``.
+An example configuration would look like this::
+
+    [{
+        "enableWriteBuffer": true,
+        "enableTemporaryFileSystemWriteBuffer": true,
+        "temporaryFileSystemSize": 10485760
+    }]
+
+The ``enableTemporaryFileSystemWriteBuffer`` setting enables the ``tmpfs``
+creation as described above, while the ``temporaryFileSystemSize`` variable
+sets the size of the ``tmpfs`` in bytes.
+
+.. Note:: The ``temporaryFileSystemSize`` parameter will not be parsed unless
+          the ``enableTemporaryFileSystemWriteBuffer`` parameter is ``true``.
+          The ``temporaryFileSystemSize`` is not required if the
+          ``enableTemporaryFileSystemWriteBuffer`` is set to ``false`` or not
+          added at all.
+
+.. Note:: The ``tmpfs`` is shared between the upper and work directories in 
+          ``overlayfs`` being mounted to the ``rootfs`` and all the 
+          directories being bindmounted into a single instance of a container.

--- a/doc/chapters/getting-started/index.rst
+++ b/doc/chapters/getting-started/index.rst
@@ -58,12 +58,20 @@ When creating containers, a configuration is passed as a JSON string. The string
 objects, in the JSON sense.
 The currently supported configs are:
 
-  * Disk writing buffer - on or off. Key: "enableWriteBuffer", value: ``true`` for on or ``false`` for off.
+  * Disk writing buffer - on or off. Key: "enableWriteBuffer", value: ``true``
+    for on or ``false`` for off.
+  * Temporary FileSystem buffers - on or off. Key:
+    "enableTemporaryFileSystemWriteBuffer", value ``true`` for on or ``false``
+    for off.
+  * Temporary FileSystem Size - integer. Key: "temporaryFileSystemSize", value:
+    Integer Size in bytes of the Temporary FileSystem Size.
 
 Example config JSON::
 
     [{
-        "enableWriteBuffer": true
+        "enableWriteBuffer": true,
+        "enableTemporaryFileSystemWriteBuffer": true,
+        "temporaryFileSystemSize": 10485760
     }]
 
 The main reason this config is passed as raw JSON is to support additions in supported config
@@ -77,6 +85,18 @@ The ``enableWriteBuffer`` is used to enable or disable write buffers on the moun
 buffers consists of a RAM overlay on top of the existing :ref:`filesystem <filesystems>`, and are
 synced to the underlying :ref:`filesystem <filesystems>` on
 shutdown of the container.
+
+The ``enableTemporaryFileSystemWriteBuffer`` is used to enable or disable the
+``tmpfs`` being mounted on top of the containers temporary filesystem
+containing temporary files. This can be used to separate the containers from
+accidentally overcommitting and thereby denying service to any other containers
+currently running.
+
+The ``temporaryFileSystemSize`` is used to set the ``RAM size`` of the
+``tmpfs`` being mounted on top of the containers temporary filesystem location.
+The variable is set in ``bytes``. This will be shared between all the
+``upper`` and ``work`` directories being mounted using ``overlayfs`` into a
+specific container.
 
 
 Working with containers

--- a/libsoftwarecontainer/include/config/softwarecontainerconfig.h
+++ b/libsoftwarecontainer/include/config/softwarecontainerconfig.h
@@ -62,6 +62,8 @@ public:
      * Setters for the values that are not part of the static configs
      */
     void setEnableWriteBuffer(bool enabledFlag);
+    void setEnableTemporaryFileSystemWriteBuffers(bool enabled);
+    void setTemporaryFileSystemSize(unsigned int size);
 
     /*
      * Getters for values that are set on creation only, i.e. these originate from the
@@ -85,6 +87,8 @@ public:
      * set after creation of this class, i.e. these can be set with setters
      */
     bool enableWriteBuffer() const;
+    bool enableTemporaryFileSystemWriteBuffers() const;
+    unsigned int temporaryFileSystemSize() const;
 
 private:
 #ifdef ENABLE_NETWORKGATEWAY
@@ -101,6 +105,8 @@ private:
     unsigned int m_containerShutdownTimeout;
 
     bool m_enableWriteBuffer;
+    bool m_enableTemporaryFileSystemWriteBuffers;
+    unsigned int m_temporaryFileSystemSize;
 };
 
 } // namespace softwarecontainer

--- a/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
+++ b/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
@@ -54,6 +54,16 @@ void SoftwareContainerConfig::setEnableWriteBuffer(bool enabledFlag)
     m_enableWriteBuffer = enabledFlag;
 }
 
+void SoftwareContainerConfig::setEnableTemporaryFileSystemWriteBuffers(bool enabled)
+{
+    m_enableTemporaryFileSystemWriteBuffers = enabled;
+}
+
+void SoftwareContainerConfig::setTemporaryFileSystemSize(unsigned int size)
+{
+    m_temporaryFileSystemSize = size;
+}
+
 std::string SoftwareContainerConfig::containerConfigPath() const
 {
     return m_containerConfigPath;
@@ -72,6 +82,16 @@ unsigned int SoftwareContainerConfig::containerShutdownTimeout() const
 bool SoftwareContainerConfig::enableWriteBuffer() const
 {
     return m_enableWriteBuffer;
+}
+
+bool SoftwareContainerConfig::enableTemporaryFileSystemWriteBuffers() const
+{
+    return m_enableTemporaryFileSystemWriteBuffers;
+}
+
+unsigned int SoftwareContainerConfig::temporaryFileSystemSize() const
+{
+    return m_temporaryFileSystemSize;
 }
 
 #ifdef ENABLE_NETWORKGATEWAY

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -65,6 +65,9 @@ SoftwareContainer::SoftwareContainer(const ContainerID id,
     m_tmpfsSize = 100485760;
     checkContainerRoot(m_containerRoot);
     if (m_config->enableWriteBuffer()) {
+        if (m_config->enableTemporaryFileSystemWriteBuffers()) {
+            m_tmpfsSize = m_config->temporaryFileSystemSize();
+        }
         tmpfsMount(m_containerRoot, m_tmpfsSize);
     }
 


### PR DESCRIPTION
This commit adds support for a tmpfs with a fixed size to be added on the temporary filesystem created for creating all container write buffers on. This will limit the impact of writes and make them contained to separate filesystems completely.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>