### PR TITLE
servicetest: Save the container ID

### DIFF
--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -336,13 +336,13 @@ class Container():
             Container.BIND_MOUNT_DIR - third argument to SoftwareContainerAgent::BindMount
             Container.READONLY - fourth argument to SoftwareContainerAgent::BindMount
         """
-        container_id = self.__create_container(data[Container.CONFIG])
+        self.__container_id = self.__create_container(data[Container.CONFIG])
 
         self.__bindmount(data[Container.HOST_PATH],
                          data[Container.BIND_MOUNT_DIR],
                          data[Container.READONLY])
         self.__bind_dir = data[Container.BIND_MOUNT_DIR]
-        return container_id
+        return self.__container_id
 
     def bindmount(self, hostpath, dirname, readonly):
         return self.__bindmount(hostpath, dirname, readonly)


### PR DESCRIPTION
The container ID should be saved in the Container class so it can be
reused by other functions.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>