### PR TITLE
Rename parameters

### DIFF
--- a/agent/component-test/softwarecontaineragent_componenttest.cpp
+++ b/agent/component-test/softwarecontaineragent_componenttest.cpp
@@ -88,7 +88,7 @@ public:
                                      "service-manifest-dir = " + std::string(SERVICE_MANIFEST_DIR_TESTING) + "\n"
                                      "default-service-manifest-dir = " + std::string(DEFAULT_SERVICE_MANIFEST_DIR_TESTING) + "\n";
 
-    const std::string valid_config = "[{\"enableWriteBuffer\": false}]";
+    const std::string valid_config = "[{\"writeBufferEnabled\": false}]";
 
     void SetUp() override
     {
@@ -163,12 +163,12 @@ TEST_F(SoftwareContainerAgentTest, DeleteContainer) {
  *TBD: This test needs to be fixed, somethings going on in it.
 TEST_F(SoftwareContainerAgentTest, CreateContainerWithConf) {
     log_error() << "gobbles1";
-    ContainerID id = sca->createContainer("[{\"enableWriteBuffer\": true}]");
+    ContainerID id = sca->createContainer("[{\"writeBufferEnabled\": true}]");
     // This is actually only true if no other containers have been created
     // before this one. Might need to be fixed somehow.
     log_error() << "gobbles2";
     ASSERT_TRUE(id == 0);
-    ASSERT_TRUE(workspace->m_enableWriteBuffer == true);
+    ASSERT_TRUE(workspace->m_writeBufferEnabled == true);
 }
  */
 

--- a/agent/src/containeroptions/containeroptionparser.cpp
+++ b/agent/src/containeroptions/containeroptionparser.cpp
@@ -37,24 +37,24 @@ void ContainerOptionParser::readConfigElement(const json_t *element)
         throw ContainerOptionParseError(errorMessage);
     }
 
-    bool enableWriteBuffer = false;
-    if(!JSONParser::read(element, "enableWriteBuffer", enableWriteBuffer)) {
-        std::string errorMessage("Could not parse config due to: 'enableWriteBuffer' not found.");
+    bool writeBufferEnabled = false;
+    if(!JSONParser::read(element, "writeBufferEnabled", writeBufferEnabled)) {
+        std::string errorMessage("Could not parse config due to: 'writeBufferEnabled' not found.");
         log_error() << errorMessage;
         throw ContainerOptionParseError(errorMessage);
     }
 
-    m_options->setEnableWriteBuffer(enableWriteBuffer);
+    m_options->setWriteBufferEnabled(writeBufferEnabled);
 
-    if (enableWriteBuffer == true) {
+    if (writeBufferEnabled == true) {
         bool enableTemporaryFilesystemWriteBuffer = false;
         if(!JSONParser::read(element,
-                             "enableTemporaryFileSystemWriteBuffer",
+                             "temporaryFileSystemWriteBufferEnabled",
                              enableTemporaryFilesystemWriteBuffer))
         {
             log_warn() << "Could not parse config due to: 'enableTemporaryFilesystemWriteBuffer' not found.";
         }
-        m_options->setEnableTemporaryFileSystemWriteBuffers(enableTemporaryFilesystemWriteBuffer);
+        m_options->setTemporaryFileSystemWriteBufferEnabled(enableTemporaryFilesystemWriteBuffer);
 
         if (enableTemporaryFilesystemWriteBuffer) {
             int temporaryFileSystemSize = DEFAULT_TEMPORARY_FILESYSTEM_SIZE;

--- a/agent/src/containeroptions/dynamiccontaineroptions.cpp
+++ b/agent/src/containeroptions/dynamiccontaineroptions.cpp
@@ -26,28 +26,28 @@ std::unique_ptr<SoftwareContainerConfig> DynamicContainerOptions::toConfig(const
     std::unique_ptr<SoftwareContainerConfig> dynamicConf = 
         std::unique_ptr<SoftwareContainerConfig>(new SoftwareContainerConfig(conf));
 
-    dynamicConf->setEnableWriteBuffer(enableWriteBuffer());
+    dynamicConf->setEnableWriteBuffer(writeBufferEnabled());
     return dynamicConf;
 }
 
-void DynamicContainerOptions::setEnableWriteBuffer(bool enabled)
+void DynamicContainerOptions::setWriteBufferEnabled(bool enabled)
 {
-    m_enableWriteBuffer = enabled;
+    m_writeBufferEnabled = enabled;
 }
 
-bool DynamicContainerOptions::enableWriteBuffer() const
+bool DynamicContainerOptions::writeBufferEnabled() const
 {
-    return m_enableWriteBuffer;
+    return m_writeBufferEnabled;
 }
 
-void DynamicContainerOptions::setEnableTemporaryFileSystemWriteBuffers(bool enabled)
+void DynamicContainerOptions::setTemporaryFileSystemWriteBufferEnabled(bool enabled)
 {
-    m_enableTemporaryFileSystemWriteBuffers = enabled;
+    m_temporaryFileSystemWriteBufferEnabled = enabled;
 }
 
-bool DynamicContainerOptions::enableTemporaryFileSystemWriteBuffers() const
+bool DynamicContainerOptions::temporaryFileSystemWriteBufferEnabled() const
 {
-    return m_enableTemporaryFileSystemWriteBuffers;
+    return m_temporaryFileSystemWriteBufferEnabled;
 }
 
 void DynamicContainerOptions::setTemporaryFileSystemSize(unsigned int size)

--- a/agent/src/containeroptions/dynamiccontaineroptions.h
+++ b/agent/src/containeroptions/dynamiccontaineroptions.h
@@ -41,18 +41,18 @@ public:
      * Setter and getter for the dynamic value on whether or not to enable
      * buffered write to disk for the container.
      */
-    void setEnableWriteBuffer(bool enabled);
-    bool enableWriteBuffer() const;
+    void setWriteBufferEnabled(bool enabled);
+    bool writeBufferEnabled() const;
 
     /**
-     * @brief Setter for the enableTemporaryFileSystemWriteBuffers variable used to tell the container
+     * @brief Setter for the temporaryFileSystemWriteBufferEnableds variable used to tell the container
      * if it shall mount a separate tmpfs on top of the temp directory
      */
-    void setEnableTemporaryFileSystemWriteBuffers(bool enabled);
+    void setTemporaryFileSystemWriteBufferEnabled(bool enabled);
     /**
-     * @brief Getter for the enableTemporaryFileSystemWriteBuffers variable
+     * @brief Getter for the temporaryFileSystemWriteBufferEnableds variable
      */
-    bool enableTemporaryFileSystemWriteBuffers() const;
+    bool temporaryFileSystemWriteBufferEnabled() const;
 
     /**
      * @brief Setter for the temporaryFileSystemSize which is used to tell the system the size of the
@@ -67,8 +67,8 @@ public:
     unsigned int temporaryFileSystemSize() const;
 
 private:
-    bool m_enableWriteBuffer = false;
-    bool m_enableTemporaryFileSystemWriteBuffers = false;
+    bool m_writeBufferEnabled = false;
+    bool m_temporaryFileSystemWriteBufferEnabled = false;
     unsigned int m_temporaryFileSystemSize;
 };
 

--- a/agent/unit-test/containeroptionparser_unittest.cpp
+++ b/agent/unit-test/containeroptionparser_unittest.cpp
@@ -48,39 +48,39 @@ public:
  * Test a simple configuration and see that it's set to true
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceEnabled) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true}]"));
+    ASSERT_TRUE(m_options->writeBufferEnabled());
 }
 
 /*
  * Test a simple configuration and make sure that it works multiple times
  */
 TEST_F(ContainerOptionParserTest, parseManyTimes) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": false}]"));
-    ASSERT_FALSE(m_options->enableWriteBuffer());
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true}]"));
+    ASSERT_TRUE(m_options->writeBufferEnabled());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": false}]"));
+    ASSERT_FALSE(m_options->writeBufferEnabled());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true}]"));
+    ASSERT_TRUE(m_options->writeBufferEnabled());
 }
 
 /*
  * Test that the configuration is disabled if it's set to being disabled
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceDisabled) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": false}]"));
-    ASSERT_FALSE(m_options->enableWriteBuffer());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": false}]"));
+    ASSERT_FALSE(m_options->writeBufferEnabled());
 }
 
 /*
  * Parse a "good" configuration with all parts set in it
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceWithTmpfsAndSize) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true, \
-                    \"enableTemporaryFileSystemWriteBuffer\": true, \
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true, \
+                    \"temporaryFileSystemWriteBufferEnabled\": true, \
                     \"temporaryFileSystemSize\": 10485760}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
-    ASSERT_TRUE(m_options->enableTemporaryFileSystemWriteBuffers());
+    ASSERT_TRUE(m_options->writeBufferEnabled());
+    ASSERT_TRUE(m_options->temporaryFileSystemWriteBufferEnabled());
     ASSERT_EQ(m_options->temporaryFileSystemSize(), 10485760);
 }
 
@@ -89,22 +89,22 @@ TEST_F(ContainerOptionParserTest, parseConfigNiceWithTmpfsAndSize) {
  * should not be parsed in that case.
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceWithTmpfsDisabled) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true, \
-                    \"enableTemporaryFileSystemWriteBuffer\": false, \
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true, \
+                    \"temporaryFileSystemWriteBufferEnabled\": false, \
                     \"temporaryFileSystemSize\": 10485760}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
-    ASSERT_FALSE(m_options->enableTemporaryFileSystemWriteBuffers());
+    ASSERT_TRUE(m_options->writeBufferEnabled());
+    ASSERT_FALSE(m_options->temporaryFileSystemWriteBufferEnabled());
 }
 
 /*
  * Parse a "good" configuration with a smaller size.
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceTmpfsEnabledSmall) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true, \
-                    \"enableTemporaryFileSystemWriteBuffer\": true, \
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true, \
+                    \"temporaryFileSystemWriteBufferEnabled\": true, \
                     \"temporaryFileSystemSize\": 100}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
-    ASSERT_TRUE(m_options->enableTemporaryFileSystemWriteBuffers());
+    ASSERT_TRUE(m_options->writeBufferEnabled());
+    ASSERT_TRUE(m_options->temporaryFileSystemWriteBufferEnabled());
     ASSERT_EQ(m_options->temporaryFileSystemSize(), 100);
 }
 
@@ -112,11 +112,11 @@ TEST_F(ContainerOptionParserTest, parseConfigNiceTmpfsEnabledSmall) {
  * Parse a "good" configuration where everything is disabled.
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceDisabledWithExtraConfig) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": false, \
-                    \"enableTemporaryFileSystemWriteBuffer\": true, \
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": false, \
+                    \"temporaryFileSystemWriteBufferEnabled\": true, \
                     \"temporaryFileSystemSize\": 100}]"));
-    ASSERT_FALSE(m_options->enableWriteBuffer());
-    ASSERT_FALSE(m_options->enableTemporaryFileSystemWriteBuffers());
+    ASSERT_FALSE(m_options->writeBufferEnabled());
+    ASSERT_FALSE(m_options->temporaryFileSystemWriteBufferEnabled());
 }
 
 /*
@@ -138,28 +138,28 @@ TEST_F(ContainerOptionParserTest, parseConfigBadConfig) {
  * parses.
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceConfigMissingSize) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true, \
-                    \"enableTemporaryFileSystemWriteBuffer\": true}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
-    ASSERT_TRUE(m_options->enableTemporaryFileSystemWriteBuffers());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true, \
+                    \"temporaryFileSystemWriteBufferEnabled\": true}]"));
+    ASSERT_TRUE(m_options->writeBufferEnabled());
+    ASSERT_TRUE(m_options->temporaryFileSystemWriteBufferEnabled());
 }
 
 /*
  * Parse a "good" config where the tmpfs is disabled and missing size.
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceConfigTmpfsDisabledMissingSize) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true, \
-                    \"enableTemporaryFileSystemWriteBuffer\": false}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
-    ASSERT_FALSE(m_options->enableTemporaryFileSystemWriteBuffers());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true, \
+                    \"temporaryFileSystemWriteBufferEnabled\": false}]"));
+    ASSERT_TRUE(m_options->writeBufferEnabled());
+    ASSERT_FALSE(m_options->temporaryFileSystemWriteBufferEnabled());
 }
 
 /*
  * Parse a "good" config where enableTemporary... and size is missing
  */
 TEST_F(ContainerOptionParserTest, parseConfigNiceConfigMissingTmpfSConfig) {
-    ASSERT_NO_THROW(parse("[{\"enableWriteBuffer\": true}]"));
-    ASSERT_TRUE(m_options->enableWriteBuffer());
+    ASSERT_NO_THROW(parse("[{\"writeBufferEnabled\": true}]"));
+    ASSERT_TRUE(m_options->writeBufferEnabled());
 }
 
 /*
@@ -167,6 +167,6 @@ TEST_F(ContainerOptionParserTest, parseConfigNiceConfigMissingTmpfSConfig) {
  */
 TEST_F(ContainerOptionParserTest, parseConfigEvilConfig) {
     ASSERT_THROW(parse("[{\"WRONG_PARAM_NAME\": true}]"), ContainerOptionParseError);
-    ASSERT_FALSE(m_options->enableWriteBuffer());
+    ASSERT_FALSE(m_options->writeBufferEnabled());
 }
 

--- a/agent/unit-test/softwarecontaineragent_unittest.cpp
+++ b/agent/unit-test/softwarecontaineragent_unittest.cpp
@@ -136,7 +136,7 @@ public:
                                      "service-manifest-dir = " + std::string(SERVICE_MANIFEST_DIR_TESTING) + "\n"
                                      "default-service-manifest-dir = " + std::string(DEFAULT_SERVICE_MANIFEST_DIR_TESTING) + "\n";
 
-    const std::string valid_config = "[{\"enableWriteBuffer\": false}]";
+    const std::string valid_config = "[{\"writeBufferEnabled\": false}]";
 
     void SetUp() override
     {

--- a/common/filetoolkitwithundo.cpp
+++ b/common/filetoolkitwithundo.cpp
@@ -54,7 +54,7 @@ bool FileToolkitWithUndo::bindMount(const std::string &src,
                                     const std::string &dst,
                                     const std::string &tmpContainerRoot,
                                     bool readOnly,
-                                    bool enableWriteBuffer)
+                                    bool writeBufferEnabled)
 {
     unsigned long flags =  0;
     std::string fstype;
@@ -73,7 +73,7 @@ bool FileToolkitWithUndo::bindMount(const std::string &src,
 
     log_debug() << "Bind-mounting " << src << " in " << dst << ", flags: " << flags;
 
-    if(enableWriteBuffer && isDirectory(src)) {
+    if(writeBufferEnabled && isDirectory(src)) {
         std::string upperDir , workDir;
 
         // In case the tmpContainerRoot is set to nothing we need to create a
@@ -90,7 +90,7 @@ bool FileToolkitWithUndo::bindMount(const std::string &src,
         std::ostringstream os;
         os << "lowerdir=" << src << ",upperdir=" << upperDir << ",workdir=" << workDir;
 
-        log_debug() << "enableWriteBuffer, config: " << os.str();
+        log_debug() << "writeBufferEnabled, config: " << os.str();
 
         mountRes = mount("overlay", dst.c_str(), fstype.c_str(), flags, os.str().c_str());
         log_debug() << "mountRes: " << mountRes;
@@ -108,7 +108,7 @@ bool FileToolkitWithUndo::bindMount(const std::string &src,
         return false;
     }
 
-    if (readOnly && !enableWriteBuffer) {
+    if (readOnly && !writeBufferEnabled) {
         const void *data = nullptr;
 
         flags = MS_REMOUNT | MS_RDONLY | MS_BIND;

--- a/common/filetoolkitwithundo.h
+++ b/common/filetoolkitwithundo.h
@@ -37,14 +37,14 @@ public:
      * @param src Path to mount from
      * @param dst Path to mount to
      * @param readOnly Make the bind mount destination read only
-     * @param enableWriteBuffer Enable write buffers on the bind mount.
+     * @param writeBufferEnabled Enable write buffers on the bind mount.
      * @return true on success, false on failure
      */
     bool bindMount(const std::string &src,
                    const std::string &dst,
                    const std::string &tmpContainerRoot,
                    bool readOnly,
-                   bool enableWriteBuffer=false);
+                   bool writeBufferEnabled=false);
 
     /**
      * @brief tmpfsMount Mount a tmpfs in the dst path and limit size of the

--- a/doc/chapters/api/index.rst
+++ b/doc/chapters/api/index.rst
@@ -84,7 +84,7 @@ Parameters
 
 Example config JSON::
 
-[{"enableWriteBuffer": true}]
+[{"writeBufferEnabled": true}]
 
 Return Values
 #############

--- a/doc/chapters/filesystem/index.rst
+++ b/doc/chapters/filesystem/index.rst
@@ -84,13 +84,13 @@ for example. Enabling the write buffer will provide a layer of
 protection for the filesystem by only allowing a final write of the changes in
 the upper layer when the container is shutting down.
 
-To enable the write buffer, set the ``enableWriteBuffer`` option in the
+To enable the write buffer, set the ``writeBufferEnabled`` option in the
 ``com.pelagicore.SoftwareContainerAgent.Create(config)`` call.
 This is done using the config parameter in specific, for example, this JSON
 config::
 
     [{
-        "enableWriteBuffer": true
+        "writeBufferEnabled": true
     }]
 
 The underlying mechanism of the write buffer is the ``OverlayFS`` which mounts a
@@ -151,19 +151,19 @@ option in the ``Create`` DBus call to the ``SoftwareContainerAgent``.
 An example configuration would look like this::
 
     [{
-        "enableWriteBuffer": true,
-        "enableTemporaryFileSystemWriteBuffer": true,
+        "writeBufferEnabled": true,
+        "temporaryFileSystemWriteBufferEnabled": true,
         "temporaryFileSystemSize": 10485760
     }]
 
-The ``enableTemporaryFileSystemWriteBuffer`` setting enables the ``tmpfs``
+The ``temporaryFileSystemWriteBufferEnabled`` setting enables the ``tmpfs``
 creation as described above, while the ``temporaryFileSystemSize`` variable
 sets the size of the ``tmpfs`` in bytes.
 
 .. Note:: The ``temporaryFileSystemSize`` parameter will not be parsed unless
-          the ``enableTemporaryFileSystemWriteBuffer`` parameter is ``true``.
+          the ``temporaryFileSystemWriteBufferEnabled`` parameter is ``true``.
           The ``temporaryFileSystemSize`` is not required if the
-          ``enableTemporaryFileSystemWriteBuffer`` is set to ``false`` or not
+          ``temporaryFileSystemWriteBufferEnabled`` is set to ``false`` or not
           added at all.
 
 .. Note:: The ``tmpfs`` is shared between the upper and work directories in 

--- a/doc/chapters/getting-started/examples/03_create_container.sh
+++ b/doc/chapters/getting-started/examples/03_create_container.sh
@@ -2,5 +2,5 @@ gdbus call --system \
 --dest com.pelagicore.SoftwareContainerAgent \
 --object-path /com/pelagicore/SoftwareContainerAgent \
 --method com.pelagicore.SoftwareContainerAgent.Create \
-'[{"enableWriteBuffer": false}]'
+'[{"writeBufferEnabled": false}]'
 

--- a/doc/chapters/getting-started/index.rst
+++ b/doc/chapters/getting-started/index.rst
@@ -58,10 +58,10 @@ When creating containers, a configuration is passed as a JSON string. The string
 objects, in the JSON sense.
 The currently supported configs are:
 
-  * Disk writing buffer - on or off. Key: "enableWriteBuffer", value: ``true``
+  * Disk writing buffer - on or off. Key: "writeBufferEnabled", value: ``true``
     for on or ``false`` for off.
   * Temporary FileSystem buffers - on or off. Key:
-    "enableTemporaryFileSystemWriteBuffer", value ``true`` for on or ``false``
+    "temporaryFileSystemWriteBufferEnabled", value ``true`` for on or ``false``
     for off.
   * Temporary FileSystem Size - integer. Key: "temporaryFileSystemSize", value:
     Integer Size in bytes of the Temporary FileSystem Size.
@@ -69,8 +69,8 @@ The currently supported configs are:
 Example config JSON::
 
     [{
-        "enableWriteBuffer": true,
-        "enableTemporaryFileSystemWriteBuffer": true,
+        "writeBufferEnabled": true,
+        "temporaryFileSystemWriteBufferEnabled": true,
         "temporaryFileSystemSize": 10485760
     }]
 
@@ -80,13 +80,13 @@ options without breaking the API.
 Write buffer configuration
 --------------------------
 
-The ``enableWriteBuffer`` is used to enable or disable write buffers on the mounted
+The ``writeBufferEnabled`` is used to enable or disable write buffers on the mounted
 :ref:`filesystems <filesystems>` in the container. These
 buffers consists of a RAM overlay on top of the existing :ref:`filesystem <filesystems>`, and are
 synced to the underlying :ref:`filesystem <filesystems>` on
 shutdown of the container.
 
-The ``enableTemporaryFileSystemWriteBuffer`` is used to enable or disable the
+The ``temporaryFileSystemWriteBufferEnabled`` is used to enable or disable the
 ``tmpfs`` being mounted on top of the containers temporary filesystem
 containing temporary files. This can be used to separate the containers from
 accidentally overcommitting and thereby denying service to any other containers

--- a/doc/chapters/integration-guidelines/10-write-buffers.rst
+++ b/doc/chapters/integration-guidelines/10-write-buffers.rst
@@ -12,13 +12,13 @@ The following snippet will create a container where a write buffer will be
 created for all filesystems in that container::
 
     [{
-        "enableWriteBuffer": true
+        "writeBufferEnabled": true
     }]
 
 The following example will disable write buffers for all filesystems within 
 the container::
 
     [{
-        "enableWriteBuffer": false
+        "writeBufferEnabled": false
     }]
 

--- a/examples/simple/launch.sh
+++ b/examples/simple/launch.sh
@@ -76,7 +76,7 @@ export SC_CMD="dbus-send --${BUS} --print-reply --dest=$SCNAME $SCOBJPATH"
 $SC_CMD org.freedesktop.DBus.Introspectable.Introspect
 
 # Create a new container
-$SC_CMD $AGENTPREFIX.Create string:'[{"enableWriteBuffer": false}]'
+$SC_CMD $AGENTPREFIX.Create string:'[{"writeBufferEnabled": false}]'
 
 # A few thing that we use for more or less every call below
 CONTAINERID="int32:0"

--- a/examples/temperature/launch.sh
+++ b/examples/temperature/launch.sh
@@ -72,7 +72,7 @@ AGENTPREFIX="com.pelagicore.SoftwareContainerAgent"
 SC_CMD="dbus-send --${BUS} --print-reply --dest=$SCNAME $SCOBJPATH"
 
 # Create a new container
-$SC_CMD $AGENTPREFIX.Create string:'[{"enableWriteBuffer": false}]'
+$SC_CMD $AGENTPREFIX.Create string:'[{"writeBufferEnabled": false}]'
 
 # A few thing that we use for more or less every call below
 CONTAINERID="int32:0"

--- a/examples/wayland/launch.sh
+++ b/examples/wayland/launch.sh
@@ -93,7 +93,7 @@ $SC_CMD org.freedesktop.DBus.Introspectable.Introspect
 $SC_CMD $AGENTPREFIX.Ping
 
 # Create a new container
-$SC_CMD $AGENTPREFIX.CreateContainer string:'[{"enableWriteBuffer": false}]'
+$SC_CMD $AGENTPREFIX.CreateContainer string:'[{"writeBufferEnabled": false}]'
 
 # A few thing that we use for more or less every call below
 CONTAINERID="int32:0"

--- a/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
+++ b/libsoftwarecontainer/component-test/softwarecontainer_test.cpp
@@ -30,7 +30,7 @@ void SoftwareContainerGatewayTest::SetUp()
         new Container("SC-0",
                       config->containerConfigPath(),
                       config->sharedMountsDir(),
-                      config->enableWriteBuffer(),
+                      config->writeBufferEnabled(),
                       config->containerShutdownTimeout()
         )
     );

--- a/libsoftwarecontainer/include/config/softwarecontainerconfig.h
+++ b/libsoftwarecontainer/include/config/softwarecontainerconfig.h
@@ -86,8 +86,8 @@ public:
      * Getters for values that do not originate from the static configs and thus might be
      * set after creation of this class, i.e. these can be set with setters
      */
-    bool enableWriteBuffer() const;
-    bool enableTemporaryFileSystemWriteBuffers() const;
+    bool writeBufferEnabled() const;
+    bool temporaryFileSystemWriteBufferEnableds() const;
     unsigned int temporaryFileSystemSize() const;
 
 private:
@@ -104,8 +104,8 @@ private:
     std::string m_sharedMountsDir;
     unsigned int m_containerShutdownTimeout;
 
-    bool m_enableWriteBuffer;
-    bool m_enableTemporaryFileSystemWriteBuffers;
+    bool m_writeBufferEnabled;
+    bool m_temporaryFileSystemWriteBufferEnableds;
     unsigned int m_temporaryFileSystemSize;
 };
 

--- a/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
+++ b/libsoftwarecontainer/src/config/softwarecontainerconfig.cpp
@@ -51,12 +51,12 @@ SoftwareContainerConfig::SoftwareContainerConfig(
 
 void SoftwareContainerConfig::setEnableWriteBuffer(bool enabledFlag)
 {
-    m_enableWriteBuffer = enabledFlag;
+    m_writeBufferEnabled = enabledFlag;
 }
 
 void SoftwareContainerConfig::setEnableTemporaryFileSystemWriteBuffers(bool enabled)
 {
-    m_enableTemporaryFileSystemWriteBuffers = enabled;
+    m_temporaryFileSystemWriteBufferEnableds = enabled;
 }
 
 void SoftwareContainerConfig::setTemporaryFileSystemSize(unsigned int size)
@@ -79,14 +79,14 @@ unsigned int SoftwareContainerConfig::containerShutdownTimeout() const
     return m_containerShutdownTimeout;
 }
 
-bool SoftwareContainerConfig::enableWriteBuffer() const
+bool SoftwareContainerConfig::writeBufferEnabled() const
 {
-    return m_enableWriteBuffer;
+    return m_writeBufferEnabled;
 }
 
-bool SoftwareContainerConfig::enableTemporaryFileSystemWriteBuffers() const
+bool SoftwareContainerConfig::temporaryFileSystemWriteBufferEnableds() const
 {
-    return m_enableTemporaryFileSystemWriteBuffers;
+    return m_temporaryFileSystemWriteBufferEnableds;
 }
 
 unsigned int SoftwareContainerConfig::temporaryFileSystemSize() const

--- a/libsoftwarecontainer/src/container.cpp
+++ b/libsoftwarecontainer/src/container.cpp
@@ -75,12 +75,12 @@ void Container::init_lxc()
 Container::Container(const std::string id,
                      const std::string &configFile,
                      const std::string &containerRoot,
-                     bool enableWriteBuffer,
+                     bool writeBufferEnabled,
                      int shutdownTimeout) :
     m_configFile(configFile),
     m_id(id),
     m_containerRoot(containerRoot),
-    m_enableWriteBuffer(enableWriteBuffer),
+    m_writeBufferEnabled(writeBufferEnabled),
     m_shutdownTimeout(shutdownTimeout)
 {
     init_lxc();
@@ -189,7 +189,7 @@ bool Container::create()
     // File system stuff
     m_rootFSPath = buildPath(s_LXCRoot, containerID, "rootfs");
 
-    if (m_enableWriteBuffer) {
+    if (m_writeBufferEnabled) {
         const std::string rootFSPathLower = m_containerRoot + "/rootfs-lower";
         const std::string rootFSPathUpper = m_containerRoot + "/rootfs-upper";
         const std::string rootFSPathWork  = m_containerRoot + "/rootfs-work";
@@ -548,7 +548,7 @@ bool Container::destroy(unsigned int timeout)
 
 
     // The container can not be destroyed unless the rootfs is unmounted
-    if (m_enableWriteBuffer)
+    if (m_writeBufferEnabled)
     {
         log_debug() << "Unmounting the overlay rootfs";
         if(-1 == umount(m_rootFSPath.c_str())) {
@@ -665,7 +665,7 @@ bool Container::bindMountCore(const std::string &pathInHost,
                    tempDirInContainerOnHost,
                    m_containerRoot,
                    readonly,
-                   m_enableWriteBuffer)) {
+                   m_writeBufferEnabled)) {
         log_error() << "Could not bind mount " << pathInHost << " to " << tempDirInContainerOnHost;
         return false;
     }

--- a/libsoftwarecontainer/src/container.h
+++ b/libsoftwarecontainer/src/container.h
@@ -75,13 +75,13 @@ public:
      * @param configFile Path to the configuration file (including the file name)
      * @param containerRoot A path to the root of the container, i.e. the base
      *  path to e.g. the configurations and application root
-     * @param enableWriteBuffer Enable RAM write buffers on top of rootfs
+     * @param writeBufferEnabled Enable RAM write buffers on top of rootfs
      * @param shutdownTimeout Timeout for shutdown of container.
      */
     Container(const std::string id,
               const std::string &configFile,
               const std::string &containerRoot,
-              bool enableWriteBuffer = false,
+              bool writeBufferEnabled = false,
               int shutdownTimeout = 1);
 
     ~Container();
@@ -261,7 +261,7 @@ private:
 
     std::string m_containerRoot;
 
-    bool m_enableWriteBuffer;
+    bool m_writeBufferEnabled;
 
     // All environment variables set by gateways
     EnvironmentVariables m_gatewayEnvironmentVariables;

--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -64,8 +64,8 @@ SoftwareContainer::SoftwareContainer(const ContainerID id,
     m_containerRoot = buildPath(m_config->sharedMountsDir(), "SC-" + std::to_string(id));
     m_tmpfsSize = 100485760;
     checkContainerRoot(m_containerRoot);
-    if (m_config->enableWriteBuffer()) {
-        if (m_config->enableTemporaryFileSystemWriteBuffers()) {
+    if (m_config->writeBufferEnabled()) {
+        if (m_config->temporaryFileSystemWriteBufferEnableds()) {
             m_tmpfsSize = m_config->temporaryFileSystemSize();
         }
         tmpfsMount(m_containerRoot, m_tmpfsSize);
@@ -79,7 +79,7 @@ SoftwareContainer::SoftwareContainer(const ContainerID id,
         new Container("SC-" + std::to_string(id),
                       m_config->containerConfigPath(),
                       m_containerRoot,
-                      m_config->enableWriteBuffer(),
+                      m_config->writeBufferEnabled(),
                       m_config->containerShutdownTimeout()));
 
     if(!init()) {

--- a/servicetest/agent/test_agent.py
+++ b/servicetest/agent/test_agent.py
@@ -47,7 +47,7 @@ def mounted_path_in_host():
     return CURRENT_DIR
 
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/capabilities/test_caps.py
+++ b/servicetest/capabilities/test_caps.py
@@ -47,7 +47,7 @@ def logfile_path():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/cgroups/test_cgroups.py
+++ b/servicetest/cgroups/test_cgroups.py
@@ -52,7 +52,7 @@ def mounted_path_in_host():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{ "enableWriteBuffer": false }]',
+    Container.CONFIG: '[{ "writeBufferEnabled": false }]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/coredump/test_coredump.py
+++ b/servicetest/coredump/test_coredump.py
@@ -46,7 +46,7 @@ def coredump_path():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/dbus/test_dbus.py
+++ b/servicetest/dbus/test_dbus.py
@@ -54,7 +54,7 @@ HOST_PATH = os.path.dirname(os.path.abspath(__file__))
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: HOST_PATH,
     Container.READONLY: False

--- a/servicetest/devicenode/test_devicenode_gateway.py
+++ b/servicetest/devicenode/test_devicenode_gateway.py
@@ -60,7 +60,7 @@ def mounted_path_in_host():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: "[{\"enableWriteBuffer\": false}]",
+    Container.CONFIG: "[{\"writeBufferEnabled\": false}]",
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: HOST_PATH,
     Container.READONLY: False

--- a/servicetest/environment/test_environment.py
+++ b/servicetest/environment/test_environment.py
@@ -79,7 +79,7 @@ def clear_env_files(scope="function"):
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: "[{\"enableWriteBuffer\": false}]",
+    Container.CONFIG: "[{\"writeBufferEnabled\": false}]",
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: HOST_PATH,
     Container.READONLY: False

--- a/servicetest/filesystem/test_filesystem.py
+++ b/servicetest/filesystem/test_filesystem.py
@@ -43,7 +43,7 @@ def logfile_path():
     return CURRENT_DIR + "/test.log"
 
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False
@@ -67,7 +67,7 @@ class TestFileSystem(object):
             file system. If it is disabled, files should be written directly
             to the file system
 
-            :TODO: If the system doesn't have overlayfs and enableWriteBuffer
+            :TODO: If the system doesn't have overlayfs and writeBufferEnabled
             is enabled, this test will work anyways since we fail to mount the
             fs containing fileapp.py, hence failing to create lala.txt, and
             hence the file isn't available after running the create process.
@@ -81,9 +81,9 @@ class TestFileSystem(object):
             os.remove(absoluteTestFile)
         ca = Container()
         if flag is True:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": true}]'
         else:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": false}]'
 
         try:
             ca.start(DATA)
@@ -121,9 +121,9 @@ class TestFileSystem(object):
 
         ca = Container()
         if flag is True:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": true}]'
         else:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": false}]'
 
         try:
             ca.start(DATA)
@@ -153,9 +153,9 @@ class TestFileSystem(object):
 
         ca = Container()
         if flag is True:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": true}]'
         else:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": false}]'
 
         try:
             ca.start(DATA)
@@ -186,9 +186,9 @@ class TestFileSystem(object):
 
         ca = Container()
         if flag is True:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": true}]'
         else:
-            DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+            DATA[Container.CONFIG] = '[{"writeBufferEnabled": false}]'
 
         try:
             ca.start(DATA)
@@ -223,7 +223,7 @@ class TestFileSystem(object):
 
         ca = Container()
 
-        DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+        DATA[Container.CONFIG] = '[{"writeBufferEnabled": true}]'
 
         try:
             id = ca.start(DATA)
@@ -277,8 +277,8 @@ class TestFileSystem(object):
 
         ca = Container()
 
-        DATA[Container.CONFIG] = '[{"enableWriteBuffer": true, \
-                                "enableTemporaryFileSystemWriteBuffer": true,\
+        DATA[Container.CONFIG] = '[{"writeBufferEnabled": true, \
+                                "temporaryFileSystemWriteBufferEnabled": true,\
                                 "temporaryFileSystemSize": ' + str(TenMB) + '}]'
         try:
             id = ca.start(DATA)
@@ -328,8 +328,8 @@ class TestFileSystem(object):
 
         absoluteTestFile = None
 
-        DATA[Container.CONFIG] = '[{"enableWriteBuffer": true, \
-                               "enableTemporaryFileSystemWriteBuffer": true}]'
+        DATA[Container.CONFIG] = '[{"writeBufferEnabled": true, \
+                               "temporaryFileSystemWriteBufferEnabled": true}]'
 
         try:
             id = ca.start(DATA)
@@ -361,14 +361,14 @@ class TestFileSystem(object):
             the bad configuration is sent to it.
 
             This run should work, but no temporary filesystem will be setup as
-            the enableTemporaryFileSystemWriteBuffer defaults to false and no
+            the temporaryFileSystemWriteBufferEnabled defaults to false and no
             parsing will be performed on the temporaryFileSystemSize parameter.
         """
         ca = Container()
 
         absoluteTestFile = None
 
-        DATA[Container.CONFIG] = '[{"enableWriteBuffer": true, \
+        DATA[Container.CONFIG] = '[{"writeBufferEnabled": true, \
                                "temporaryFileSystemSize": ' + str(TenMB) + '}]'
 
         try:
@@ -407,7 +407,7 @@ class TestFileSystem(object):
 
         ca = Container()
 
-        DATA[Container.CONFIG] = '[{"enableWriteBuffer": false}]'
+        DATA[Container.CONFIG] = '[{"writeBufferEnabled": false}]'
 
         try:
             id = ca.start(DATA)

--- a/servicetest/filesystem/test_filesystem_strace.py
+++ b/servicetest/filesystem/test_filesystem_strace.py
@@ -47,7 +47,7 @@ def agent_exec_prefix():
     return "strace"
 
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False
@@ -125,7 +125,7 @@ class TestFileSystemStrace(object):
             server.bind(absolute_test_file)
 
         ca = Container()
-        DATA[Container.CONFIG] = '[{"enableWriteBuffer": true}]'
+        DATA[Container.CONFIG] = '[{"writeBufferEnabled": true}]'
 
         try:
             ca.start(DATA)

--- a/servicetest/networkgateway/test_network_gateway.py
+++ b/servicetest/networkgateway/test_network_gateway.py
@@ -54,7 +54,7 @@ def mounted_path_in_host():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/queries/test_queries.py
+++ b/servicetest/queries/test_queries.py
@@ -49,7 +49,7 @@ def logfile_path():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/suspend/test_suspend.py
+++ b/servicetest/suspend/test_suspend.py
@@ -40,7 +40,7 @@ def logfile_path():
 # configurations to the Container helper. Tests that need to add, remove or
 # update entries can simply base their dict on this one for convenience.
 DATA = {
-    Container.CONFIG: '[{"enableWriteBuffer": false}]',
+    Container.CONFIG: '[{"writeBufferEnabled": false}]',
     Container.BIND_MOUNT_DIR: "/gateways/app",
     Container.HOST_PATH: CURRENT_DIR,
     Container.READONLY: False

--- a/servicetest/testframework/lib.py
+++ b/servicetest/testframework/lib.py
@@ -323,7 +323,7 @@ class Container():
 
             The user should pass a dict like e.g.:
             {
-                Container.CONFIG: "{enableWriteBuffer: false}",
+                Container.CONFIG: "{writeBufferEnabled: false}",
                 Container.HOST_PATH: my_path_string_variable,
                 Container.BIND_MOUNT_DIR: "app",
                 Container.READONLY: True

--- a/servicetest/timingprofiling/test_profiling.py
+++ b/servicetest/timingprofiling/test_profiling.py
@@ -98,7 +98,7 @@ def run_test(num_starts=3):
 
             # A basic container configuration, content is not important for this test.
             container_data = {
-                Container.CONFIG: '[{"enableWriteBuffer": false}]',
+                Container.CONFIG: '[{"writeBufferEnabled": false}]',
                 Container.BIND_MOUNT_DIR: "/gateways/app",
                 Container.HOST_PATH: CURRENT_DIR,
                 Container.READONLY: False


### PR DESCRIPTION
* enableWriteBuffer was renamed to writeBufferEnabled
* enableTemporaryFileSystemWriteBuffer was renamed to
  temporaryFileSystemWriteBufferEnabled

This to make the use of the parameter and accompanying methods a bit
clearer.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>