### PR TITLE
update lxc config element names

### DIFF
--- a/libsoftwarecontainer/lxc-softwarecontainer.in
+++ b/libsoftwarecontainer/lxc-softwarecontainer.in
@@ -124,7 +124,7 @@ copy_configuration()
     rootfs=$2
 
     # Set some non-static mount points, the rest are already in the config file
-    echo "lxc.rootfs = $rootfs" >> $path/config
+    echo "lxc.rootfs.path = $rootfs" >> $path/config
     echo "lxc.mount.entry = ${CMAKE_INSTALL_PREFIX} $rootfs/${CMAKE_INSTALL_PREFIX} none ro,bind 0 0" >> $path/config
 
     # Bind-mount the necessary binaries into the container
@@ -172,8 +172,8 @@ fi
 # detect rootfs (either from contents in config, or by using $path
 if [ -z "$rootfs" ]; then
     config="$path/config"
-    if grep -q '^lxc.rootfs' $config 2>/dev/null ; then
-        rootfs=`grep 'lxc.rootfs =' $config | awk -F= '{ print $2 }'`
+    if grep -q '^lxc.rootfs.path' $config 2>/dev/null ; then
+        rootfs=`grep 'lxc.rootfs.path =' $config | awk -F: '{ print $2 }'`
     else
         rootfs=$path/rootfs
     fi

--- a/libsoftwarecontainer/softwarecontainer.conf.in
+++ b/libsoftwarecontainer/softwarecontainer.conf.in
@@ -1,13 +1,13 @@
-lxc.utsname=contained
+lxc.uts.name=contained
 
 lxc.autodev = 1
-lxc.tty = 1
-lxc.pts = 1
+lxc.tty.max = 1
+lxc.pty.max = 1
 
 #
 # TODO: Remove this when we get the shutdown timeout issue fixed.
 #
-lxc.haltsignal = SIGKILL
+lxc.signal.halt = SIGKILL
 
 @NETWORK_LXC_CONF@
 

--- a/libsoftwarecontainer/softwarecontainer_network.conf.in
+++ b/libsoftwarecontainer/softwarecontainer_network.conf.in
@@ -1,3 +1,3 @@
-lxc.network.type = veth
-lxc.network.link = @SC_BRIDGE_DEVICE@
-lxc.network.name = eth0
+lxc.net.0.type = veth
+lxc.net.0.link = @SC_BRIDGE_DEVICE@
+lxc.net.0.name = eth0


### PR DESCRIPTION
Several of the lxc config element names have been
renamed in lxc 3 version. This results in failing
to load lxc configuration after upgrading the lxc
version. This fixes the issue by renaming the
config element names to the newer names.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>