### PR TITLE
README.md: add missing building step

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ $ sudo apt-get install lxc lxc-dev libglib2.0-dev libglibmm-2.4 \
 
 # Building
 Building and installing is simple:
+
+Update the submodules in softwarecontainer git repo to get dbus-proxy and vagrant cookbook modules
+
 ```
+$ git submodule update --init
 $ mkdir build
 $ cd build
 $ cmake ../


### PR DESCRIPTION
An important step to update git submodules was missing,
which includes the required dbus-proxy and vagrant
cookbook submodules to build. Updated the README.md
to add this step

Signed-off-by: Tariq Ansari <tansari@luxoft.com>