### PR TITLE
servicetests: use pytest3 and python3-lxc binding

### DIFF
--- a/servicetest/run-tests.sh
+++ b/servicetest/run-tests.sh
@@ -25,5 +25,5 @@ fi
 # cd to the directory of this script.
 cd "$(dirname "$0")"
 
-py.test -v -k "not agent" --junit-xml=servicetest_result.xml
-py.test -v -k "agent" --junit-xml=agent_servicetest_result.xml
+py.test-3 -v -k "not agent" --junit-xml=servicetest_result.xml
+py.test-3 -v -k "agent" --junit-xml=agent_servicetest_result.xml


### PR DESCRIPTION
Service tests require pytest-3 and python3-lxc bindings to run
after the softwarecontainer is updated to use lxc3 version.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>