### PR TITLE
waylandgateway: Use WAYLAND_DISPLAY environment variable

### DIFF
--- a/libsoftwarecontainer/src/gateway/waylandgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.cpp
@@ -26,8 +26,8 @@ namespace softwarecontainer {
 // These lines are needed in order to define the fields, which otherwise would
 // yield linker errors.
 constexpr const char *WaylandGateway::ENABLED_FIELD;
-constexpr const char *WaylandGateway::SOCKET_FILE_NAME;
 constexpr const char *WaylandGateway::WAYLAND_RUNTIME_DIR_VARIABLE_NAME;
+constexpr const char *WAYLAND_SOCKET_FILE_VARIABLE_NAME;
 
 WaylandGateway::WaylandGateway(std::shared_ptr<ContainerAbstractInterface> container) :
     Gateway(ID, container, true /*this GW is dynamic*/),
@@ -70,6 +70,12 @@ bool WaylandGateway::activateGateway()
     if (m_enabled && m_activatedOnce) {
         log_info() << "Ignoring redundant activation";
         return true;
+    }
+
+    std::string SOCKET_FILE_NAME = Glib::getenv(WAYLAND_SOCKET_FILE_VARIABLE_NAME);
+    if (SOCKET_FILE_NAME.empty()) {
+        log_error() << "Missing Wayland socket file name. " << WAYLAND_SOCKET_FILE_VARIABLE_NAME << " environment variable not set";
+        return false;
     }
 
     bool hasWayland = false;

--- a/libsoftwarecontainer/src/gateway/waylandgateway.h
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.h
@@ -31,7 +31,7 @@ class WaylandGateway :
 public:
     static constexpr const char *ID = "wayland";
     static constexpr const char *WAYLAND_RUNTIME_DIR_VARIABLE_NAME = "XDG_RUNTIME_DIR";
-    static constexpr const char *SOCKET_FILE_NAME = "wayland-0";
+    static constexpr const char *WAYLAND_SOCKET_FILE_VARIABLE_NAME = "WAYLAND_DISPLAY";
     static constexpr const char *ENABLED_FIELD = "enabled";
 
     WaylandGateway(std::shared_ptr<ContainerAbstractInterface> container);


### PR DESCRIPTION
The wayland socket file name was hardcoded to wayland-0 in
wayland gateway. This resulted in failure when the socket
name was changed on the filesystem. This fix enables updating
the the socket name by setting WAYLAND_DISPLAY environment
variable to the socket name on the file system.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>