### PR TITLE
waylandgateway: Fix uninitialized const variable

### DIFF
--- a/libsoftwarecontainer/src/gateway/waylandgateway.cpp
+++ b/libsoftwarecontainer/src/gateway/waylandgateway.cpp
@@ -27,7 +27,7 @@ namespace softwarecontainer {
 // yield linker errors.
 constexpr const char *WaylandGateway::ENABLED_FIELD;
 constexpr const char *WaylandGateway::WAYLAND_RUNTIME_DIR_VARIABLE_NAME;
-constexpr const char *WAYLAND_SOCKET_FILE_VARIABLE_NAME;
+constexpr const char *WaylandGateway::WAYLAND_SOCKET_FILE_VARIABLE_NAME;
 
 WaylandGateway::WaylandGateway(std::shared_ptr<ContainerAbstractInterface> container) :
     Gateway(ID, container, true /*this GW is dynamic*/),


### PR DESCRIPTION
Signed-off-by: Tariq Ansari <tansari@luxoft.com>