### PR TITLE
filegateway: fix gateway activation order

### DIFF
--- a/libsoftwarecontainer/src/softwarecontainer.cpp
+++ b/libsoftwarecontainer/src/softwarecontainer.cpp
@@ -124,6 +124,10 @@ bool SoftwareContainer::init()
         return false;
     }
 
+#ifdef ENABLE_FILEGATEWAY
+    m_gateways.push_back( std::unique_ptr<Gateway>(new FileGateway(m_container)) );
+#endif
+
 #ifdef ENABLE_NETWORKGATEWAY
     try {
         m_gateways.push_back( std::unique_ptr<Gateway>(new NetworkGateway(
@@ -162,10 +166,6 @@ bool SoftwareContainer::init()
 
 #ifdef ENABLE_ENVGATEWAY
     m_gateways.push_back( std::unique_ptr<Gateway>(new EnvironmentGateway(m_container)) );
-#endif
-
-#ifdef ENABLE_FILEGATEWAY
-    m_gateways.push_back( std::unique_ptr<Gateway>(new FileGateway(m_container)) );
 #endif
 
     return true;


### PR DESCRIPTION
The filegateway was activated after activation of other
gateways which might need access to some specific files
added via filegateway. This caused the files not being
available to the gateways that required these files. This
fixes the order so that filegateway is always activated
before other gateways.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>